### PR TITLE
ci: align workflow with validate-layer1.sh validations

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -82,6 +82,7 @@ jobs:
           mkdir -p nanvix-artifacts/extracted
           tar -xjf "$ARTIFACT_FILE" -C nanvix-artifacts/extracted
           NANVIX_HOME=$(find nanvix-artifacts/extracted -maxdepth 2 -type d -name "bin" -exec dirname {} \; | head -1)
+          mkdir -p "$NANVIX_HOME/include"
           echo "NANVIX_HOME=$NANVIX_HOME" >> "$GITHUB_ENV"
 
       - name: Build
@@ -101,7 +102,7 @@ jobs:
 
       - name: Functional Tests
         run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
+          timeout --foreground 300 make -f Makefile.nanvix CONFIG_NANVIX=y \
             NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-functional
 
       - name: Package
@@ -112,6 +113,21 @@ jobs:
             package
           ARTIFACT_NAME="zlib-${{ matrix.platform }}-${{ matrix.process-mode }}"
           echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
+
+      - name: Verify Package
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$ARTIFACT_TARBALL" ]]; then
+            echo "::error::Package tarball not found: $ARTIFACT_TARBALL"
+            exit 1
+          fi
+          if ! tar tjf "$ARTIFACT_TARBALL" | grep -q '^sysroot/lib/'; then
+            echo "::error::Package missing sysroot/lib/ entries"
+            tar tjf "$ARTIFACT_TARBALL"
+            exit 1
+          fi
+          echo "Package contents:"
+          tar tjf "$ARTIFACT_TARBALL"
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Align the Nanvix CI workflow with the validations performed by `validate-layer1.sh`:

- **`mkdir -p "$NANVIX_HOME/include"`** — ensure the sysroot include directory exists before the build (matches the local script's `mkdir -p "$sysroot/include"`)
- **`timeout --foreground 300`** on functional tests — prevent hanging builds (matches the 300s timeout in the local script)
- **Verify Package step** — check the tarball exists and contains `sysroot/lib/` entries (matches the local script's package verification)