### PR TITLE
ci: move verify-package step from workflow to Makefile

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -116,18 +116,10 @@ jobs:
 
       - name: Verify Package
         run: |
-          set -euo pipefail
-          TARBALL="dist/zlib-${{ matrix.platform }}-${{ matrix.process-mode }}.tar.bz2"
-          if [[ ! -f "$TARBALL" ]]; then
-            echo "::error::Package tarball not found: $TARBALL"
-            exit 1
-          fi
-          echo "Package contents:"
-          tar tjf "$TARBALL"
-          if ! (set +o pipefail; tar tjf "$TARBALL" | grep -q 'sysroot/lib/'); then
-            echo "::error::Package missing sysroot/lib/ entries"
-            exit 1
-          fi
+          make -f Makefile.nanvix CONFIG_NANVIX=y \
+            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
+            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
+            verify-package
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
@@ -213,13 +205,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
+          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
           echo "Triggering sqlite workflow..."
           gh api repos/nanvix/sqlite/dispatches \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -f event_type="zlib-release" \
             -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
-            -f "client_payload[zlib_tag]=${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}" || echo "::warning::Failed to trigger sqlite workflow"
+            -f "client_payload[zlib_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger sqlite workflow"
 
   report-failure:
     needs: [build]

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -214,6 +214,24 @@ package: all
 	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
 
 # ===========================================================================
+# Verify Package
+# ===========================================================================
+
+verify-package:
+	@echo "=== Verifying zlib package ==="
+	$(eval ARTIFACT_NAME := zlib-$(PLATFORM)-$(PROCESS_MODE))
+	@TARBALL="dist/$(ARTIFACT_NAME).tar.bz2"; \
+	if [ ! -f "$$TARBALL" ]; then \
+	  echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \
+	fi; \
+	echo "Package contents:"; \
+	tar tjf "$$TARBALL"; \
+	if ! tar tjf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
+	  echo "FAIL: Package missing sysroot/lib/ entries"; exit 1; \
+	fi; \
+	echo "  PASS: zlib package verification"
+
+# ===========================================================================
 # Install / Clean
 # ===========================================================================
 
@@ -228,4 +246,4 @@ clean:
 	rm -f *.a *.elf
 	rm -rf dist/
 
-.PHONY: all clean test test-smoke test-integration test-functional package install
+.PHONY: all clean test test-smoke test-integration test-functional package verify-package install


### PR DESCRIPTION
Move the inline package verification logic from `nanvix-ci.yml` into a `verify-package` target in `Makefile.nanvix`.

**Changes:**
- Add `verify-package` target to `Makefile.nanvix` that checks tarball existence, lists contents, and verifies `sysroot/lib/` entries
- Replace inline shell in CI workflow's "Verify Package" step with `make verify-package`
- Use `RELEASE_TAG` variable in "Trigger Dependent Workflows" step for consistency

**Benefits:**
- Package verification is now runnable locally (`make -f Makefile.nanvix ... verify-package`)
- Eliminates duplicated logic between CI workflow and validation script
- Consistent structure across all Layer 1 submodule workflows

**Tested:** `./validate-layer1.sh --docker` and `./validate-layer1.sh` both pass 20/20 with 0 skips.