### PR TITLE
ci: align Makefile.nanvix with cross-submodule consistency

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -96,7 +96,7 @@ ifdef CONFIG_NANVIX
   endif
 else
   ifneq ($(MAKECMDGOALS),clean)
-    $(error CONFIG_NANVIX must be set. Usage: make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/sysroot)
+    $(error CONFIG_NANVIX must be set to 'y'. Usage: make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/sysroot)
   endif
   EXE = .elf
 endif
@@ -186,7 +186,7 @@ test-functional: test-integration
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "  Running example$(EXE) via nanvixd.elf (Docker)..."
 	$(DOCKER_RUN_FUNCTIONAL) sh -c \
-	  'timeout 120 ./bin/nanvixd.elf -- $(DOCKER_WORKSPACE_PATH)/example$(EXE) /tmp/zlib_test'
+	  'timeout --foreground 120 ./bin/nanvixd.elf -- $(DOCKER_WORKSPACE_PATH)/example$(EXE) /tmp/zlib_test'
 	@echo "  PASS: example test (exit code 0)"
 else
 	@echo "  Running example$(EXE) via nanvixd.elf..."
@@ -212,6 +212,8 @@ package: all
 	-cp -f $(TEST_PROGS) dist/$(ARTIFACT_NAME)/sysroot/bin/ 2>/dev/null || true
 	tar -cjf dist/$(ARTIFACT_NAME).tar.bz2 -C dist/$(ARTIFACT_NAME) sysroot
 	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
+	@echo "  Contents:"
+	@tar tjf dist/$(ARTIFACT_NAME).tar.bz2 | head -20
 
 # ===========================================================================
 # Verify Package


### PR DESCRIPTION
Align zlib's Makefile.nanvix with the consistency standards used across all Layer 1 submodules:

- Fix CONFIG_NANVIX error message to include "to 'y'" (matching bzip2, libexpat, libffi, sqlite, openssl)
- Add `--foreground` flag to Docker timeout in functional tests (matching bzip2, libexpat, libffi, sqlite)
- Add package contents listing after tarball creation (matching bzip2, libexpat, libffi, sqlite, openssl)

Validated locally: all 4 platform/process-mode configurations pass (build, smoke, integration, functional, package, verify-package) with zero skips.