### PR TITLE
Migrate to ZScript build system and CI (z, z.ps1, .nanvix/z.py, nanvix-ci.yml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ contrib/nuget/obj
 .z.cache
 minigzip.elf
 example.elf
+
+# Nanvix build state (keep .nanvix/z.py tracked)
+.nanvix/venv/
+.nanvix/cache/
+.nanvix/sysroot/
+.nanvix/buildroot/
+.nanvix/env.json

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -19,26 +19,17 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import sysconfig
 from pathlib import Path
 
 _NANVIX_DIR = Path(__file__).resolve().parent
 _VENV = _NANVIX_DIR / "venv"
-_VENV_SCRIPTS = Path(
-    sysconfig.get_path("scripts", vars={"base": str(_VENV), "platbase": str(_VENV)})
-)
-_VENV_PYTHON = _VENV_SCRIPTS / ("python.exe" if os.name == "nt" else "python")
-_ZUTIL_TAG = "v0.1.0-rc1"
+_VENV_PYTHON = _VENV / ("Scripts" if os.name == "nt" else "bin") / ("python.exe" if os.name == "nt" else "python")
+_ZUTIL_TAG = "v0.1.0-rc2"
 
 
 def _inside_venv() -> bool:
     """Return True if already running inside the project venv."""
-    if sys.prefix == sys.base_prefix:
-        return False
-    try:
-        return Path(sys.executable).resolve().is_relative_to(_VENV.resolve())
-    except (OSError, ValueError):
-        return False
+    return sys.prefix != sys.base_prefix
 
 
 def _zutil_urls() -> tuple[str, str, str]:

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -22,50 +22,36 @@ import sys
 from pathlib import Path
 
 _NANVIX_DIR = Path(__file__).resolve().parent
-_VENV_DIR = _NANVIX_DIR / "venv"
+_VENV = _NANVIX_DIR / "venv"
+_VENV_PYTHON = _VENV / ("Scripts" if os.name == "nt" else "bin") / "python"
 _ZUTIL_VERSION = "0.1.0"
+# TODO: Replace with actual GitHub release URL once available.
+_ZUTIL_RELEASE_URL = ""
 
-
-def _bootstrap() -> None:
-    """Ensure nanvix-zutil is installed in the local venv, then re-exec."""
-    # Already running inside the venv — nothing to do.
-    if sys.prefix != sys.base_prefix:
-        return
-
-    if not (_VENV_DIR / "pyvenv.cfg").exists():
-        print(f"info: Creating virtual environment at {_VENV_DIR}", flush=True)
-        subprocess.run(
-            [sys.executable, "-m", "venv", str(_VENV_DIR)],
-            check=True,
-        )
-
-    # Determine venv Python path (cross-platform).
-    if sys.platform == "win32":
-        venv_python = _VENV_DIR / "Scripts" / "python.exe"
-    else:
-        venv_python = _VENV_DIR / "bin" / "python"
-
-    if not venv_python.exists():
-        print(f"error: venv Python not found at {venv_python}", file=sys.stderr)
-        sys.exit(3)
-
-    # Install nanvix-zutil: from local path (dev) or PyPI (release).
-    local_path = os.environ.get("NANVIX_ZUTIL_PATH")
-    if local_path:
-        pip_args = [str(venv_python), "-m", "pip", "install", "--quiet", "-e", local_path]
-    else:
-        pip_args = [
-            str(venv_python), "-m", "pip", "install", "--quiet",
-            f"nanvix-zutil=={_ZUTIL_VERSION}",
-        ]
-
-    subprocess.run(pip_args, check=True)
-
-    # Re-exec under venv Python.
-    os.execv(str(venv_python), [str(venv_python), *sys.argv])
-
-
-_bootstrap()
+if not sys.prefix.startswith(str(_VENV)):
+    if not _VENV.exists():
+        print("bootstrap: creating venv …", flush=True)
+        subprocess.check_call([sys.executable, "-m", "venv", str(_VENV)])
+        print("bootstrap: installing nanvix-zutil …", flush=True)
+        local_path = os.environ.get("NANVIX_ZUTIL_PATH")
+        if local_path:
+            subprocess.check_call(
+                [str(_VENV_PYTHON), "-m", "pip", "install", "-q", "-e", local_path]
+            )
+        elif _ZUTIL_RELEASE_URL:
+            subprocess.check_call(
+                [str(_VENV_PYTHON), "-m", "pip", "install", "-q", _ZUTIL_RELEASE_URL]
+            )
+        else:
+            print(
+                "error: NANVIX_ZUTIL_PATH not set and release URL is not configured.",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+    rc = subprocess.call(
+        [str(_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]]
+    )
+    sys.exit(rc)
 
 # ===== Build script (runs inside venv) =====
 

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -19,76 +19,20 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 _NANVIX_DIR = Path(__file__).resolve().parent
 _VENV = _NANVIX_DIR / "venv"
 _VENV_PYTHON = _VENV / ("Scripts" if os.name == "nt" else "bin") / ("python.exe" if os.name == "nt" else "python")
 _ZUTIL_TAG = "v0.1.0-rc2"
+_ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
+_ZUTIL_HASH = "sha256:728a6ac6c9265ce58727569156c21877f94dbf6b449849a28585ccc6cde1b91f"
 
 
 def _inside_venv() -> bool:
     """Return True if already running inside the project venv."""
     return sys.prefix != sys.base_prefix
-
-
-def _zutil_urls() -> tuple[str, str, str]:
-    """Derive wheel URL, checksums URL, and wheel filename from the pinned tag."""
-    version = _ZUTIL_TAG.lstrip("v").replace("-", "")
-    whl_name = f"nanvix_zutil-{version}-py3-none-any.whl"
-    base = f"https://github.com/nanvix/zutils/releases/download/{_ZUTIL_TAG}"
-    return f"{base}/{whl_name}", f"{base}/checksums.sha256", whl_name
-
-
-def _verify_and_install_wheel() -> None:
-    """Download the nanvix-zutil wheel, verify its hash, and install it."""
-    import hashlib
-    import tempfile
-    import urllib.error
-    import urllib.request
-
-    whl_url, checksums_url, whl_name = _zutil_urls()
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        whl_path = Path(tmpdir) / whl_name
-        print(f"bootstrap: downloading nanvix-zutil ({_ZUTIL_TAG}) …", flush=True)
-        urllib.request.urlretrieve(whl_url, whl_path)
-
-        expected_hash: str | None = None
-        try:
-            with urllib.request.urlopen(checksums_url) as resp:
-                for line in resp.read().decode().splitlines():
-                    parts = line.split()
-                    if len(parts) == 2 and parts[1].strip("*") == whl_name:
-                        expected_hash = parts[0]
-                        break
-        except urllib.error.URLError as exc:
-            print(
-                f"error: could not fetch checksums for nanvix-zutil: {exc}",
-                file=sys.stderr,
-            )
-            sys.exit(4)
-
-        if not expected_hash:
-            print(
-                f"error: no checksum entry for {whl_name} in {checksums_url}",
-                file=sys.stderr,
-            )
-            sys.exit(4)
-
-        actual = hashlib.sha256(whl_path.read_bytes()).hexdigest()
-        if actual != expected_hash:
-            print(
-                f"error: hash mismatch for nanvix-zutil wheel\n"
-                f"  expected: {expected_hash}\n"
-                f"  actual:   {actual}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        subprocess.check_call(
-            [str(_VENV_PYTHON), "-m", "pip", "install", "-q", str(whl_path)]
-        )
 
 
 def _create_venv() -> None:
@@ -102,7 +46,21 @@ def _create_venv() -> None:
             [str(_VENV_PYTHON), "-m", "pip", "install", "-q", "-e", local_path]
         )
     else:
-        _verify_and_install_wheel()
+        version = _ZUTIL_TAG.lstrip("v").replace("-", "")
+        whl_name = f"nanvix_zutil-{version}-py3-none-any.whl"
+        whl_url = f"{_ZUTIL_RELEASE_BASE}/{_ZUTIL_TAG}/{whl_name}"
+        req_line = f"nanvix_zutil @ {whl_url} --hash={_ZUTIL_HASH}"
+        print(f"bootstrap: installing nanvix-zutil ({_ZUTIL_TAG}) …", flush=True)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(req_line + "\n")
+            req_path = f.name
+        try:
+            subprocess.check_call(
+                [str(_VENV_PYTHON), "-m", "pip", "install", "-q",
+                 "--require-hashes", "-r", req_path]
+            )
+        finally:
+            Path(req_path).unlink(missing_ok=True)
 
 
 if not _inside_venv():
@@ -117,6 +75,23 @@ if not _inside_venv():
 
 from nanvix_zutil import ZScript, Sysroot, log  # noqa: E402
 
+# Make variable names passed to Makefile.nanvix.
+_MAKE_VAR_CONFIG = "CONFIG_NANVIX"
+_MAKE_VAR_HOME = "NANVIX_HOME"
+_MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
+_MAKE_VAR_PLATFORM = "PLATFORM"
+_MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
+_MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
+
+# Config keys.
+_CFG_SYSROOT = "NANVIX_SYSROOT"
+_CFG_TOOLCHAIN = "NANVIX_TOOLCHAIN"
+_CFG_TAG = "NANVIX_TAG"
+_CFG_GH_TOKEN = "GH_TOKEN"
+
+# Sysroot verification files.
+_SYSROOT_REQUIRED_FILES = ["lib/libposix.a", "lib/user.ld"]
+
 
 class ZlibBuild(ZScript):
     """Build script for nanvix/zlib."""
@@ -129,20 +104,20 @@ class ZlibBuild(ZScript):
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
         self.config.load()
-        sysroot = self.config.get("NANVIX_SYSROOT", "")
+        sysroot = self.config.get(_CFG_SYSROOT, "")
         if not sysroot:
             log.fatal(
-                "NANVIX_SYSROOT is not set.",
+                f"{_CFG_SYSROOT} is not set.",
                 code=3,
                 hint="Run `./z setup` first to download the sysroot.",
             )
-        toolchain = self.config.get("NANVIX_TOOLCHAIN", "/opt/nanvix")
+        toolchain = self.config.get(_CFG_TOOLCHAIN, "/opt/nanvix")
 
         args = [
             "make", "-f", "Makefile.nanvix",
-            "CONFIG_NANVIX=y",
-            f"NANVIX_HOME={sysroot}",
-            f"NANVIX_TOOLCHAIN={toolchain}",
+            f"{_MAKE_VAR_CONFIG}=y",
+            f"{_MAKE_VAR_HOME}={sysroot}",
+            f"{_MAKE_VAR_TOOLCHAIN}={toolchain}",
         ]
 
         # Pass platform parameters when set.
@@ -150,9 +125,9 @@ class ZlibBuild(ZScript):
         mode = self.config.deployment_mode
         mem = self.config.memory_size
         args.extend([
-            f"PLATFORM={machine}",
-            f"PROCESS_MODE={mode}",
-            f"MEMORY_SIZE={mem}",
+            f"{_MAKE_VAR_PLATFORM}={machine}",
+            f"{_MAKE_VAR_PROCESS_MODE}={mode}",
+            f"{_MAKE_VAR_MEMORY_SIZE}={mem}",
         ])
 
         args.extend(targets)
@@ -160,19 +135,19 @@ class ZlibBuild(ZScript):
 
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
-        tag = self.config.get("NANVIX_TAG", self.NANVIX_TAG)
+        tag = self.config.get(_CFG_TAG, self.NANVIX_TAG)
         if not tag:
-            log.fatal("NANVIX_TAG is not set.", code=3)
+            log.fatal(f"{_CFG_TAG} is not set.", code=3)
 
         sysroot = Sysroot.download(
             machine=self.config.machine,
             deployment_mode=self.config.deployment_mode,
             memory_size=self.config.memory_size,
             tag=tag,
-            gh_token=self.config.get("GH_TOKEN"),
+            gh_token=self.config.get(_CFG_GH_TOKEN),
         )
-        sysroot.verify(["lib/libposix.a", "lib/user.ld"])
-        self.config.set("NANVIX_SYSROOT", str(sysroot.path))
+        sysroot.verify(_SYSROOT_REQUIRED_FILES)
+        self.config.set(_CFG_SYSROOT, str(sysroot.path))
         self.config.save()
         log.success("Setup complete")
 

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -13,6 +13,9 @@ Usage:
 
 from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TAG, CFG_TOOLCHAIN, Sysroot, ZScript, log
 
+# Exit codes (mirrors nanvix-zutil convention).
+_EXIT_MISSING_DEP = 3
+
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
 _MAKE_VAR_HOME = "NANVIX_HOME"
@@ -33,7 +36,7 @@ class ZlibBuild(ZScript):
         if not sysroot:
             log.fatal(
                 f"{CFG_SYSROOT} is not set.",
-                code=3,
+                code=_EXIT_MISSING_DEP,
                 hint="Run `./z setup` first to download the sysroot.",
             )
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
@@ -58,7 +61,7 @@ class ZlibBuild(ZScript):
         """Download the Nanvix sysroot."""
         tag = self.config.get(CFG_TAG, self.NANVIX_TAG)
         if not tag:
-            log.fatal(f"{CFG_TAG} is not set.", code=3)
+            log.fatal(f"{CFG_TAG} is not set.", code=_EXIT_MISSING_DEP)
 
         sysroot = Sysroot.download(
             machine=self.config.machine,

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -28,8 +28,7 @@ _VENV_SCRIPTS = Path(
     sysconfig.get_path("scripts", vars={"base": str(_VENV), "platbase": str(_VENV)})
 )
 _VENV_PYTHON = _VENV_SCRIPTS / ("python.exe" if os.name == "nt" else "python")
-_ZUTIL_RELEASE_URL = "https://github.com/nanvix/zutils/releases/download/v0.1.0-rc1/nanvix_zutil-0.1.0rc1-py3-none-any.whl"
-_ZUTIL_HASH = "sha256:55df7a1ee81e401d6f9ead6a8e970c05599e3de7e66ff223a0186e5ad982d863"
+_ZUTIL_TAG = "v0.1.0-rc1"
 
 
 def _inside_venv() -> bool:
@@ -42,24 +41,48 @@ def _inside_venv() -> bool:
         return False
 
 
+def _zutil_urls() -> tuple[str, str, str]:
+    """Derive wheel URL, checksums URL, and wheel filename from the pinned tag."""
+    version = _ZUTIL_TAG.lstrip("v").replace("-", "")
+    whl_name = f"nanvix_zutil-{version}-py3-none-any.whl"
+    base = f"https://github.com/nanvix/zutils/releases/download/{_ZUTIL_TAG}"
+    return f"{base}/{whl_name}", f"{base}/checksums.sha256", whl_name
+
+
 def _verify_and_install_wheel() -> None:
     """Download the nanvix-zutil wheel, verify its hash, and install it."""
     import hashlib
     import tempfile
+    import urllib.error
     import urllib.request
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        whl_path = Path(tmpdir) / "nanvix_zutil.whl"
-        print("bootstrap: downloading nanvix-zutil …", flush=True)
-        urllib.request.urlretrieve(_ZUTIL_RELEASE_URL, whl_path)
+    whl_url, checksums_url, whl_name = _zutil_urls()
 
-        if _ZUTIL_HASH:
-            algo, _, expected = _ZUTIL_HASH.partition(":")
-            actual = hashlib.new(algo, whl_path.read_bytes()).hexdigest()
-            if actual != expected:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        whl_path = Path(tmpdir) / whl_name
+        print(f"bootstrap: downloading nanvix-zutil ({_ZUTIL_TAG}) …", flush=True)
+        urllib.request.urlretrieve(whl_url, whl_path)
+
+        expected_hash: str | None = None
+        try:
+            with urllib.request.urlopen(checksums_url) as resp:
+                for line in resp.read().decode().splitlines():
+                    if whl_name in line:
+                        expected_hash = line.split()[0]
+                        break
+        except urllib.error.URLError:
+            print(
+                "warning: could not fetch checksums, skipping verification",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        if expected_hash:
+            actual = hashlib.sha256(whl_path.read_bytes()).hexdigest()
+            if actual != expected_hash:
                 print(
                     f"error: hash mismatch for nanvix-zutil wheel\n"
-                    f"  expected: {expected}\n"
+                    f"  expected: {expected_hash}\n"
                     f"  actual:   {actual}",
                     file=sys.stderr,
                 )

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -19,34 +19,74 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
 _NANVIX_DIR = Path(__file__).resolve().parent
 _VENV = _NANVIX_DIR / "venv"
-_VENV_PYTHON = _VENV / ("Scripts" if os.name == "nt" else "bin") / "python"
-_ZUTIL_VERSION = "0.1.0rc1"
+_VENV_SCRIPTS = Path(
+    sysconfig.get_path("scripts", vars={"base": str(_VENV), "platbase": str(_VENV)})
+)
+_VENV_PYTHON = _VENV_SCRIPTS / ("python.exe" if os.name == "nt" else "python")
 _ZUTIL_RELEASE_URL = "https://github.com/nanvix/zutils/releases/download/v0.1.0-rc1/nanvix_zutil-0.1.0rc1-py3-none-any.whl"
+_ZUTIL_HASH = "sha256:55df7a1ee81e401d6f9ead6a8e970c05599e3de7e66ff223a0186e5ad982d863"
 
-if not sys.prefix.startswith(str(_VENV)):
-    if not _VENV.exists():
-        print("bootstrap: creating venv …", flush=True)
-        subprocess.check_call([sys.executable, "-m", "venv", str(_VENV)])
-        print("bootstrap: installing nanvix-zutil …", flush=True)
-        local_path = os.environ.get("NANVIX_ZUTIL_PATH")
-        if local_path:
-            subprocess.check_call(
-                [str(_VENV_PYTHON), "-m", "pip", "install", "-q", "-e", local_path]
-            )
-        elif _ZUTIL_RELEASE_URL:
-            subprocess.check_call(
-                [str(_VENV_PYTHON), "-m", "pip", "install", "-q", _ZUTIL_RELEASE_URL]
-            )
-        else:
-            print(
-                "error: NANVIX_ZUTIL_PATH not set and release URL is not configured.",
-                file=sys.stderr,
-            )
-            sys.exit(3)
+
+def _inside_venv() -> bool:
+    """Return True if already running inside the project venv."""
+    if sys.prefix == sys.base_prefix:
+        return False
+    try:
+        return Path(sys.executable).resolve().is_relative_to(_VENV.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+def _verify_and_install_wheel() -> None:
+    """Download the nanvix-zutil wheel, verify its hash, and install it."""
+    import hashlib
+    import tempfile
+    import urllib.request
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        whl_path = Path(tmpdir) / "nanvix_zutil.whl"
+        print("bootstrap: downloading nanvix-zutil …", flush=True)
+        urllib.request.urlretrieve(_ZUTIL_RELEASE_URL, whl_path)
+
+        if _ZUTIL_HASH:
+            algo, _, expected = _ZUTIL_HASH.partition(":")
+            actual = hashlib.new(algo, whl_path.read_bytes()).hexdigest()
+            if actual != expected:
+                print(
+                    f"error: hash mismatch for nanvix-zutil wheel\n"
+                    f"  expected: {expected}\n"
+                    f"  actual:   {actual}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+        subprocess.check_call(
+            [str(_VENV_PYTHON), "-m", "pip", "install", "-q", str(whl_path)]
+        )
+
+
+def _create_venv() -> None:
+    """Create the venv and install nanvix-zutil."""
+    print("bootstrap: creating venv …", flush=True)
+    subprocess.check_call([sys.executable, "-m", "venv", str(_VENV)])
+    local_path = os.environ.get("NANVIX_ZUTIL_PATH")
+    if local_path:
+        print("bootstrap: installing nanvix-zutil (editable) …", flush=True)
+        subprocess.check_call(
+            [str(_VENV_PYTHON), "-m", "pip", "install", "-q", "-e", local_path]
+        )
+    else:
+        _verify_and_install_wheel()
+
+
+if not _inside_venv():
+    if not _VENV_PYTHON.exists():
+        _create_venv()
     rc = subprocess.call(
         [str(_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]]
     )
@@ -93,7 +133,8 @@ class ZlibBuild(ZScript):
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
         tag = self.config.get("NANVIX_TAG", self.NANVIX_TAG)
-        assert tag is not None
+        if not tag:
+            log.fatal("NANVIX_TAG is not set.", code=3)
 
         sysroot = Sysroot.download(
             machine=self.config.machine,

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -1,0 +1,153 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Nanvix build script for zlib.
+
+Usage:
+    ./z setup     # Download Nanvix sysroot
+    ./z build     # Cross-compile libz.a
+    ./z test      # Run test suite (smoke + integration + functional)
+    ./z release   # Package release tarball
+    ./z clean     # Remove build artifacts
+"""
+
+# ===== Self-bootstrapping preamble (stdlib only) =====
+# Creates .nanvix/venv/, installs nanvix-zutil, re-execs under venv Python.
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_NANVIX_DIR = Path(__file__).resolve().parent
+_VENV_DIR = _NANVIX_DIR / "venv"
+_ZUTIL_VERSION = "0.1.0"
+
+
+def _bootstrap() -> None:
+    """Ensure nanvix-zutil is installed in the local venv, then re-exec."""
+    # Already running inside the venv — nothing to do.
+    if sys.prefix != sys.base_prefix:
+        return
+
+    if not (_VENV_DIR / "pyvenv.cfg").exists():
+        print(f"info: Creating virtual environment at {_VENV_DIR}", flush=True)
+        subprocess.run(
+            [sys.executable, "-m", "venv", str(_VENV_DIR)],
+            check=True,
+        )
+
+    # Determine venv Python path (cross-platform).
+    if sys.platform == "win32":
+        venv_python = _VENV_DIR / "Scripts" / "python.exe"
+    else:
+        venv_python = _VENV_DIR / "bin" / "python"
+
+    if not venv_python.exists():
+        print(f"error: venv Python not found at {venv_python}", file=sys.stderr)
+        sys.exit(3)
+
+    # Install nanvix-zutil: from local path (dev) or PyPI (release).
+    local_path = os.environ.get("NANVIX_ZUTIL_PATH")
+    if local_path:
+        pip_args = [str(venv_python), "-m", "pip", "install", "--quiet", "-e", local_path]
+    else:
+        pip_args = [
+            str(venv_python), "-m", "pip", "install", "--quiet",
+            f"nanvix-zutil=={_ZUTIL_VERSION}",
+        ]
+
+    subprocess.run(pip_args, check=True)
+
+    # Re-exec under venv Python.
+    os.execv(str(venv_python), [str(venv_python), *sys.argv])
+
+
+_bootstrap()
+
+# ===== Build script (runs inside venv) =====
+
+from nanvix_zutil import ZScript, Sysroot, log  # noqa: E402
+
+
+class ZlibBuild(ZScript):
+    """Build script for nanvix/zlib."""
+
+    # zlib is a leaf library — no build-time dependencies.
+
+    # Nanvix sysroot release tag. Override with NANVIX_TAG env var.
+    NANVIX_TAG = "latest"
+
+    def _make_args(self, *targets: str) -> list[str]:
+        """Build the common make argument list."""
+        sysroot = self.config.get("NANVIX_SYSROOT", "")
+        toolchain = self.config.get("NANVIX_TOOLCHAIN", "/opt/nanvix")
+
+        args = [
+            "make", "-f", "Makefile.nanvix",
+            "CONFIG_NANVIX=y",
+            f"NANVIX_HOME={sysroot}",
+            f"NANVIX_TOOLCHAIN={toolchain}",
+        ]
+
+        # Pass platform parameters when set.
+        machine = self.config.machine
+        mode = self.config.deployment_mode
+        mem = self.config.memory_size
+        args.extend([
+            f"PLATFORM={machine}",
+            f"PROCESS_MODE={mode}",
+            f"MEMORY_SIZE={mem}",
+        ])
+
+        args.extend(targets)
+        return args
+
+    def setup(self) -> None:
+        """Download the Nanvix sysroot."""
+        tag = self.config.get("NANVIX_TAG", self.NANVIX_TAG)
+        assert tag is not None
+
+        sysroot = Sysroot.download(
+            machine=self.config.machine,
+            deployment_mode=self.config.deployment_mode,
+            memory_size=self.config.memory_size,
+            tag=tag,
+            gh_token=self.config.get("GH_TOKEN"),
+        )
+        sysroot.verify(["lib/libposix.a", "lib/user.ld"])
+        self.config.set("NANVIX_SYSROOT", str(sysroot.path))
+        self.config.save()
+        log.success("Setup complete")
+
+    def build(self) -> None:
+        """Cross-compile libz.a for Nanvix."""
+        self.config.load()
+        self.run(*self._make_args("all"), cwd=self.repo_root)
+        log.success("Build complete")
+
+    def test(self) -> None:
+        """Run the zlib test suite (smoke + integration + functional)."""
+        self.config.load()
+        self.run(*self._make_args("test"), cwd=self.repo_root)
+        log.success("Tests passed")
+
+    def release(self) -> None:
+        """Package the zlib release tarball."""
+        self.config.load()
+        self.run(*self._make_args("package"), cwd=self.repo_root)
+        log.success("Release packaged")
+
+    def clean(self) -> None:
+        """Remove build artifacts."""
+        self.run(
+            "make", "-f", "Makefile.nanvix", "clean",
+            cwd=self.repo_root,
+        )
+        log.success("Clean complete")
+
+
+if __name__ == "__main__":
+    ZlibBuild.main()

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -24,9 +24,8 @@ from pathlib import Path
 _NANVIX_DIR = Path(__file__).resolve().parent
 _VENV = _NANVIX_DIR / "venv"
 _VENV_PYTHON = _VENV / ("Scripts" if os.name == "nt" else "bin") / "python"
-_ZUTIL_VERSION = "0.1.0"
-# TODO: Replace with actual GitHub release URL once available.
-_ZUTIL_RELEASE_URL = ""
+_ZUTIL_VERSION = "0.1.0rc1"
+_ZUTIL_RELEASE_URL = "https://github.com/nanvix/zutils/releases/download/v0.1.0-rc1/nanvix_zutil-0.1.0rc1-py3-none-any.whl"
 
 if not sys.prefix.startswith(str(_VENV)):
     if not _VENV.exists():

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,71 +11,9 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
-# ===== Self-bootstrapping preamble (stdlib only) =====
-# Creates .nanvix/venv/, installs nanvix-zutil, re-execs under venv Python.
+from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TAG, CFG_TOOLCHAIN, Sysroot, ZScript, log
 
-from __future__ import annotations
-
-import os
-import subprocess
-import sys
-import tempfile
-from pathlib import Path
-
-_NANVIX_DIR = Path(__file__).resolve().parent
-_VENV = _NANVIX_DIR / "venv"
-_VENV_PYTHON = _VENV / ("Scripts" if os.name == "nt" else "bin") / ("python.exe" if os.name == "nt" else "python")
-_ZUTIL_TAG = "v0.1.0-rc2"
-_ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-_ZUTIL_HASH = "sha256:728a6ac6c9265ce58727569156c21877f94dbf6b449849a28585ccc6cde1b91f"
-
-
-def _inside_venv() -> bool:
-    """Return True if already running inside the project venv."""
-    return sys.prefix != sys.base_prefix
-
-
-def _create_venv() -> None:
-    """Create the venv and install nanvix-zutil."""
-    print("bootstrap: creating venv …", flush=True)
-    subprocess.check_call([sys.executable, "-m", "venv", str(_VENV)])
-    local_path = os.environ.get("NANVIX_ZUTIL_PATH")
-    if local_path:
-        print("bootstrap: installing nanvix-zutil (editable) …", flush=True)
-        subprocess.check_call(
-            [str(_VENV_PYTHON), "-m", "pip", "install", "-q", "-e", local_path]
-        )
-    else:
-        version = _ZUTIL_TAG.lstrip("v").replace("-", "")
-        whl_name = f"nanvix_zutil-{version}-py3-none-any.whl"
-        whl_url = f"{_ZUTIL_RELEASE_BASE}/{_ZUTIL_TAG}/{whl_name}"
-        req_line = f"nanvix_zutil @ {whl_url} --hash={_ZUTIL_HASH}"
-        print(f"bootstrap: installing nanvix-zutil ({_ZUTIL_TAG}) …", flush=True)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write(req_line + "\n")
-            req_path = f.name
-        try:
-            subprocess.check_call(
-                [str(_VENV_PYTHON), "-m", "pip", "install", "-q",
-                 "--require-hashes", "-r", req_path]
-            )
-        finally:
-            Path(req_path).unlink(missing_ok=True)
-
-
-if not _inside_venv():
-    if not _VENV_PYTHON.exists():
-        _create_venv()
-    rc = subprocess.call(
-        [str(_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]]
-    )
-    sys.exit(rc)
-
-# ===== Build script (runs inside venv) =====
-
-from nanvix_zutil import ZScript, Sysroot, log  # noqa: E402
-
-# Make variable names passed to Makefile.nanvix.
+# Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
 _MAKE_VAR_HOME = "NANVIX_HOME"
 _MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
@@ -83,35 +21,22 @@ _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
-# Config keys.
-_CFG_SYSROOT = "NANVIX_SYSROOT"
-_CFG_TOOLCHAIN = "NANVIX_TOOLCHAIN"
-_CFG_TAG = "NANVIX_TAG"
-_CFG_GH_TOKEN = "GH_TOKEN"
-
-# Sysroot verification files.
-_SYSROOT_REQUIRED_FILES = ["lib/libposix.a", "lib/user.ld"]
-
 
 class ZlibBuild(ZScript):
     """Build script for nanvix/zlib."""
 
-    # zlib is a leaf library — no build-time dependencies.
-
-    # Nanvix sysroot release tag. Override with NANVIX_TAG env var.
     NANVIX_TAG = "latest"
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
-        self.config.load()
-        sysroot = self.config.get(_CFG_SYSROOT, "")
+        sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
             log.fatal(
-                f"{_CFG_SYSROOT} is not set.",
+                f"{CFG_SYSROOT} is not set.",
                 code=3,
                 hint="Run `./z setup` first to download the sysroot.",
             )
-        toolchain = self.config.get(_CFG_TOOLCHAIN, "/opt/nanvix")
+        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
 
         args = [
             "make", "-f", "Makefile.nanvix",
@@ -120,14 +45,10 @@ class ZlibBuild(ZScript):
             f"{_MAKE_VAR_TOOLCHAIN}={toolchain}",
         ]
 
-        # Pass platform parameters when set.
-        machine = self.config.machine
-        mode = self.config.deployment_mode
-        mem = self.config.memory_size
         args.extend([
-            f"{_MAKE_VAR_PLATFORM}={machine}",
-            f"{_MAKE_VAR_PROCESS_MODE}={mode}",
-            f"{_MAKE_VAR_MEMORY_SIZE}={mem}",
+            f"{_MAKE_VAR_PLATFORM}={self.config.machine}",
+            f"{_MAKE_VAR_PROCESS_MODE}={self.config.deployment_mode}",
+            f"{_MAKE_VAR_MEMORY_SIZE}={self.config.memory_size}",
         ])
 
         args.extend(targets)
@@ -135,39 +56,32 @@ class ZlibBuild(ZScript):
 
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
-        tag = self.config.get(_CFG_TAG, self.NANVIX_TAG)
+        tag = self.config.get(CFG_TAG, self.NANVIX_TAG)
         if not tag:
-            log.fatal(f"{_CFG_TAG} is not set.", code=3)
+            log.fatal(f"{CFG_TAG} is not set.", code=3)
 
         sysroot = Sysroot.download(
             machine=self.config.machine,
             deployment_mode=self.config.deployment_mode,
             memory_size=self.config.memory_size,
             tag=tag,
-            gh_token=self.config.get(_CFG_GH_TOKEN),
+            gh_token=self.config.get(CFG_GH_TOKEN),
         )
-        sysroot.verify(_SYSROOT_REQUIRED_FILES)
-        self.config.set(_CFG_SYSROOT, str(sysroot.path))
+        sysroot.verify(list(self.SYSROOT_REQUIRED_FILES))
+        self.config.set(CFG_SYSROOT, str(sysroot.path))
         self.config.save()
-        log.success("Setup complete")
 
     def build(self) -> None:
         """Cross-compile libz.a for Nanvix."""
-        self.config.load()
         self.run(*self._make_args("all"), cwd=self.repo_root)
-        log.success("Build complete")
 
     def test(self) -> None:
         """Run the zlib test suite (smoke + integration + functional)."""
-        self.config.load()
         self.run(*self._make_args("test"), cwd=self.repo_root)
-        log.success("Tests passed")
 
     def release(self) -> None:
         """Package the zlib release tarball."""
-        self.config.load()
         self.run(*self._make_args("package"), cwd=self.repo_root)
-        log.success("Release packaged")
 
     def clean(self) -> None:
         """Remove build artifacts."""
@@ -175,7 +89,6 @@ class ZlibBuild(ZScript):
             "make", "-f", "Makefile.nanvix", "clean",
             cwd=self.repo_root,
         )
-        log.success("Clean complete")
 
 
 if __name__ == "__main__":

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -58,26 +58,33 @@ def _verify_and_install_wheel() -> None:
         try:
             with urllib.request.urlopen(checksums_url) as resp:
                 for line in resp.read().decode().splitlines():
-                    if whl_name in line:
-                        expected_hash = line.split()[0]
+                    parts = line.split()
+                    if len(parts) == 2 and parts[1].strip("*") == whl_name:
+                        expected_hash = parts[0]
                         break
-        except urllib.error.URLError:
+        except urllib.error.URLError as exc:
             print(
-                "warning: could not fetch checksums, skipping verification",
+                f"error: could not fetch checksums for nanvix-zutil: {exc}",
                 file=sys.stderr,
-                flush=True,
             )
+            sys.exit(4)
 
-        if expected_hash:
-            actual = hashlib.sha256(whl_path.read_bytes()).hexdigest()
-            if actual != expected_hash:
-                print(
-                    f"error: hash mismatch for nanvix-zutil wheel\n"
-                    f"  expected: {expected_hash}\n"
-                    f"  actual:   {actual}",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+        if not expected_hash:
+            print(
+                f"error: no checksum entry for {whl_name} in {checksums_url}",
+                file=sys.stderr,
+            )
+            sys.exit(4)
+
+        actual = hashlib.sha256(whl_path.read_bytes()).hexdigest()
+        if actual != expected_hash:
+            print(
+                f"error: hash mismatch for nanvix-zutil wheel\n"
+                f"  expected: {expected_hash}\n"
+                f"  actual:   {actual}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         subprocess.check_call(
             [str(_VENV_PYTHON), "-m", "pip", "install", "-q", str(whl_path)]
@@ -121,7 +128,14 @@ class ZlibBuild(ZScript):
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
+        self.config.load()
         sysroot = self.config.get("NANVIX_SYSROOT", "")
+        if not sysroot:
+            log.fatal(
+                "NANVIX_SYSROOT is not set.",
+                code=3,
+                hint="Run `./z setup` first to download the sysroot.",
+            )
         toolchain = self.config.get("NANVIX_TOOLCHAIN", "/opt/nanvix")
 
         args = [

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,10 +11,7 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
-from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TAG, CFG_TOOLCHAIN, Sysroot, ZScript, log
-
-# Exit codes (mirrors nanvix-zutil convention).
-_EXIT_MISSING_DEP = 3
+from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TAG, CFG_TOOLCHAIN, EXIT_MISSING_DEP, Sysroot, ZScript, log
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
@@ -36,7 +33,7 @@ class ZlibBuild(ZScript):
         if not sysroot:
             log.fatal(
                 f"{CFG_SYSROOT} is not set.",
-                code=_EXIT_MISSING_DEP,
+                code=EXIT_MISSING_DEP,
                 hint="Run `./z setup` first to download the sysroot.",
             )
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
@@ -61,7 +58,7 @@ class ZlibBuild(ZScript):
         """Download the Nanvix sysroot."""
         tag = self.config.get(CFG_TAG, self.NANVIX_TAG)
         if not tag:
-            log.fatal(f"{CFG_TAG} is not set.", code=_EXIT_MISSING_DEP)
+            log.fatal(f"{CFG_TAG} is not set.", code=EXIT_MISSING_DEP)
 
         sysroot = Sysroot.download(
             machine=self.config.machine,

--- a/z
+++ b/z
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Bootstrap wrapper for Nanvix build scripts.
+# Modeled on https://github.com/rust-lang/rust/blob/main/x
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+# Minimum required Python version.
+MIN_PYTHON_MAJOR=3
+MIN_PYTHON_MINOR=12
+
+# Locate a suitable Python interpreter.
+find_python() {
+    local candidates=("python3" "python" "py")
+    for candidate in "${candidates[@]}"; do
+        if command -v "${candidate}" &>/dev/null; then
+            local version
+            version=$("${candidate}" -c \
+                "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
+                2>/dev/null) || continue
+            local major minor
+            major=$(echo "${version}" | cut -d. -f1)
+            minor=$(echo "${version}" | cut -d. -f2)
+            if [[ "${major}" -gt "${MIN_PYTHON_MAJOR}" ]] || \
+               [[ "${major}" -eq "${MIN_PYTHON_MAJOR}" && "${minor}" -ge "${MIN_PYTHON_MINOR}" ]]; then
+                echo "${candidate}"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+PYTHON=$(find_python) || {
+    echo "error: Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ not found in PATH." >&2
+    echo "hint:  Install Python 3.12+ and ensure it is on your PATH." >&2
+    exit 3
+}
+
+# Resolve the directory containing this script, following symlinks.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
+
+if [[ ! -f "${Z_SCRIPT}" ]]; then
+    echo "error: ${Z_SCRIPT} not found." >&2
+    echo "hint:  Create .nanvix/z.py with a ZScript subclass." >&2
+    exit 3
+fi
+
+exec "${PYTHON}" "${Z_SCRIPT}" "$@"

--- a/z
+++ b/z
@@ -17,9 +17,15 @@ find_python() {
     for candidate in "${candidates[@]}"; do
         if command -v "${candidate}" &>/dev/null; then
             local version
-            version=$("${candidate}" -c \
-                "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
-                2>/dev/null) || continue
+            if [[ "${candidate}" == "py" ]]; then
+                version=$("${candidate}" -3 -c \
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
+                    2>/dev/null) || continue
+            else
+                version=$("${candidate}" -c \
+                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
+                    2>/dev/null) || continue
+            fi
             local major minor
             major=$(echo "${version}" | cut -d. -f1)
             minor=$(echo "${version}" | cut -d. -f2)
@@ -49,4 +55,8 @@ if [[ ! -f "${Z_SCRIPT}" ]]; then
     exit 3
 fi
 
-exec "${PYTHON}" "${Z_SCRIPT}" "$@"
+if [[ "${PYTHON}" == "py" ]]; then
+    exec "${PYTHON}" -3 "${Z_SCRIPT}" "$@"
+else
+    exec "${PYTHON}" "${Z_SCRIPT}" "$@"
+fi

--- a/z
+++ b/z
@@ -13,7 +13,14 @@ MIN_PYTHON_MINOR=12
 
 # Locate a suitable Python interpreter.
 find_python() {
-    local candidates=("python3" "python" "py")
+    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
+    # then fall back to generic names.
+    local candidates=()
+    local minor
+    for ((minor=20; minor>=MIN_PYTHON_MINOR; minor--)); do
+        candidates+=("python3.${minor}")
+    done
+    candidates+=("python3" "python" "py")
     for candidate in "${candidates[@]}"; do
         if command -v "${candidate}" &>/dev/null; then
             local version

--- a/z
+++ b/z
@@ -27,8 +27,8 @@ find_python() {
                     2>/dev/null) || continue
             fi
             local major minor
-            major=$(echo "${version}" | cut -d. -f1)
-            minor=$(echo "${version}" | cut -d. -f2)
+            major=$(echo "${version}" | tr -d '\r' | cut -d. -f1)
+            minor=$(echo "${version}" | tr -d '\r' | cut -d. -f2)
             if [[ "${major}" -gt "${MIN_PYTHON_MAJOR}" ]] || \
                [[ "${major}" -eq "${MIN_PYTHON_MAJOR}" && "${minor}" -ge "${MIN_PYTHON_MINOR}" ]]; then
                 echo "${candidate}"

--- a/z
+++ b/z
@@ -45,7 +45,7 @@ PYTHON=$(find_python) || {
     exit 3
 }
 
-# Resolve the directory containing this script, following symlinks.
+# Resolve the directory containing this script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
 

--- a/z
+++ b/z
@@ -12,9 +12,9 @@ MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.1.0"
+ZUTIL_TAG="v0.1.1"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+ZUTIL_HASH="sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
 
 # Locate a suitable Python interpreter.
 find_python() {
@@ -70,7 +70,13 @@ PYTHON=$(find_python) || {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
 VENV_DIR="${SCRIPT_DIR}/.nanvix/venv"
-VENV_PYTHON="${VENV_DIR}/bin/python"
+
+# Detect venv interpreter path (Scripts/python.exe on Windows/MSYS).
+if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
+    VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
+else
+    VENV_PYTHON="${VENV_DIR}/bin/python"
+fi
 
 if [[ ! -f "${Z_SCRIPT}" ]]; then
     echo "error: ${Z_SCRIPT} not found." >&2
@@ -83,6 +89,11 @@ if [[ ! -f "${VENV_PYTHON}" ]]; then
     echo "bootstrap: creating venv …" >&2
     run_python -m venv "${VENV_DIR}"
 
+    # Re-detect after venv creation.
+    if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
+        VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
+    fi
+
     if [[ -n "${NANVIX_ZUTIL_PATH:-}" ]]; then
         echo "bootstrap: installing nanvix-zutil (editable) …" >&2
         "${VENV_PYTHON}" -m pip install -q -e "${NANVIX_ZUTIL_PATH}"
@@ -93,9 +104,11 @@ if [[ ! -f "${VENV_PYTHON}" ]]; then
         whl_url="${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whl_name}"
         echo "bootstrap: installing nanvix-zutil (${ZUTIL_TAG}) …" >&2
         tmp_req=$(mktemp)
+        trap 'rm -f "${tmp_req}"' EXIT
         echo "nanvix_zutil @ ${whl_url} --hash=${ZUTIL_HASH}" > "${tmp_req}"
         "${VENV_PYTHON}" -m pip install -q --require-hashes -r "${tmp_req}"
         rm -f "${tmp_req}"
+        trap - EXIT
     fi
 fi
 

--- a/z
+++ b/z
@@ -11,6 +11,11 @@ set -euo pipefail
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
+# nanvix-zutil release to install in the project venv.
+ZUTIL_TAG="v0.1.0"
+ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
+ZUTIL_HASH="sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+
 # Locate a suitable Python interpreter.
 find_python() {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
@@ -46,6 +51,15 @@ find_python() {
     return 1
 }
 
+# Run the discovered Python interpreter (handles 'py -3' on Windows).
+run_python() {
+    if [[ "${PYTHON}" == "py" ]]; then
+        "${PYTHON}" -3 "$@"
+    else
+        "${PYTHON}" "$@"
+    fi
+}
+
 PYTHON=$(find_python) || {
     echo "error: Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ not found in PATH." >&2
     echo "hint:  Install Python 3.12+ and ensure it is on your PATH." >&2
@@ -55,6 +69,8 @@ PYTHON=$(find_python) || {
 # Resolve the directory containing this script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
+VENV_DIR="${SCRIPT_DIR}/.nanvix/venv"
+VENV_PYTHON="${VENV_DIR}/bin/python"
 
 if [[ ! -f "${Z_SCRIPT}" ]]; then
     echo "error: ${Z_SCRIPT} not found." >&2
@@ -62,8 +78,25 @@ if [[ ! -f "${Z_SCRIPT}" ]]; then
     exit 3
 fi
 
-if [[ "${PYTHON}" == "py" ]]; then
-    exec "${PYTHON}" -3 "${Z_SCRIPT}" "$@"
-else
-    exec "${PYTHON}" "${Z_SCRIPT}" "$@"
+# Bootstrap: create venv and install nanvix-zutil if needed.
+if [[ ! -f "${VENV_PYTHON}" ]]; then
+    echo "bootstrap: creating venv …" >&2
+    run_python -m venv "${VENV_DIR}"
+
+    if [[ -n "${NANVIX_ZUTIL_PATH:-}" ]]; then
+        echo "bootstrap: installing nanvix-zutil (editable) …" >&2
+        "${VENV_PYTHON}" -m pip install -q -e "${NANVIX_ZUTIL_PATH}"
+    else
+        version="${ZUTIL_TAG#v}"
+        version="${version//-/}"
+        whl_name="nanvix_zutil-${version}-py3-none-any.whl"
+        whl_url="${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whl_name}"
+        echo "bootstrap: installing nanvix-zutil (${ZUTIL_TAG}) …" >&2
+        tmp_req=$(mktemp)
+        echo "nanvix_zutil @ ${whl_url} --hash=${ZUTIL_HASH}" > "${tmp_req}"
+        "${VENV_PYTHON}" -m pip install -q --require-hashes -r "${tmp_req}"
+        rm -f "${tmp_req}"
+    fi
 fi
+
+exec "${VENV_PYTHON}" "${Z_SCRIPT}" "$@"

--- a/z
+++ b/z
@@ -16,9 +16,9 @@ EXIT_GENERAL_ERROR=1
 EXIT_MISSING_DEP=3
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.1.1"
+ZUTIL_TAG="v0.2.0"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
+ZUTIL_HASH="sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
 
 # Locate a suitable Python interpreter.
 find_python() {

--- a/z
+++ b/z
@@ -11,6 +11,10 @@ set -euo pipefail
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=12
 
+# Exit codes (mirrors nanvix-zutil convention).
+EXIT_GENERAL_ERROR=1
+EXIT_MISSING_DEP=3
+
 # nanvix-zutil release to install in the project venv.
 ZUTIL_TAG="v0.1.1"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
@@ -48,7 +52,7 @@ find_python() {
             fi
         fi
     done
-    return 1
+    return "${EXIT_GENERAL_ERROR}"
 }
 
 # Run the discovered Python interpreter (handles 'py -3' on Windows).
@@ -63,7 +67,7 @@ run_python() {
 PYTHON=$(find_python) || {
     echo "error: Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ not found in PATH." >&2
     echo "hint:  Install Python 3.12+ and ensure it is on your PATH." >&2
-    exit 3
+    exit "${EXIT_MISSING_DEP}"
 }
 
 # Resolve the directory containing this script.
@@ -81,7 +85,7 @@ fi
 if [[ ! -f "${Z_SCRIPT}" ]]; then
     echo "error: ${Z_SCRIPT} not found." >&2
     echo "hint:  Create .nanvix/z.py with a ZScript subclass." >&2
-    exit 3
+    exit "${EXIT_MISSING_DEP}"
 fi
 
 # Bootstrap: create venv and install nanvix-zutil if needed.

--- a/z.ps1
+++ b/z.ps1
@@ -7,7 +7,7 @@
 # If script execution is disabled, run:
 #   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
-#Requires -Version 5.1
+#Requires -Version 7.0
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
@@ -64,7 +64,7 @@ function Invoke-Python {
 
 $python = Find-Python
 if ($null -eq $python) {
-    Write-Host "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH." -ForegroundColor Red
+    Write-Warning "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH."
     Write-Host "hint:  Install Python 3.12+ and ensure it is on your PATH." -ForegroundColor Yellow
     exit 3
 }
@@ -72,15 +72,14 @@ if ($null -eq $python) {
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $zScript = Join-Path $scriptDir ".nanvix" "z.py"
 $venvDir = Join-Path $scriptDir ".nanvix" "venv"
-$isWin = ($PSVersionTable.PSEdition -eq "Desktop") -or $IsWindows
-if ($isWin) {
+if ($IsWindows) {
     $venvPython = Join-Path $venvDir "Scripts" "python.exe"
 } else {
     $venvPython = Join-Path $venvDir "bin" "python"
 }
 
 if (-not (Test-Path $zScript)) {
-    Write-Host "error: $zScript not found." -ForegroundColor Red
+    Write-Warning "error: $zScript not found."
     Write-Host "hint:  Create .nanvix/z.py with a ZScript subclass." -ForegroundColor Yellow
     exit 3
 }

--- a/z.ps1
+++ b/z.ps1
@@ -16,9 +16,9 @@ $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.1.0"
+$ZUTIL_TAG = "v0.1.1"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+$ZUTIL_HASH = "sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
@@ -27,17 +27,13 @@ function Find-Python {
     for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
         $candidates += "python3.$minor"
     }
-    $candidates += @("py", "python3", "python")
+    $candidates += @("python3", "python")
     foreach ($candidate in $candidates) {
         $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
         if ($null -eq $cmd) { continue }
 
-        # For 'py', pass -3 to select Python 3.
-        $pyArgs = if ($candidate -eq "py") { @("-3", "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") } `
-                  else { @("-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") }
-
         try {
-            $version = & $candidate @pyArgs 2>$null
+            $version = & $candidate -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
             if ($LASTEXITCODE -ne 0) { continue }
             $parts = $version.Trim().Split(".")
             $major = [int]$parts[0]
@@ -49,17 +45,29 @@ function Find-Python {
             continue
         }
     }
+
+    # Windows 'py' launcher: probe specific minor versions (high to low).
+    $pyCmd = Get-Command "py" -ErrorAction SilentlyContinue
+    if ($null -ne $pyCmd) {
+        for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
+            try {
+                $exe = & py "-3.$minor" -c "import sys; print(sys.executable)" 2>$null
+                if ($LASTEXITCODE -eq 0 -and $exe) {
+                    return $exe.Trim()
+                }
+            } catch {
+                continue
+            }
+        }
+    }
+
     return $null
 }
 
-# Run the discovered Python interpreter (handles 'py -3' on Windows).
+# Run the discovered Python interpreter.
 function Invoke-Python {
     param([Parameter(ValueFromRemainingArguments)] [string[]]$Args_)
-    if ($python -eq "py") {
-        & $python -3 @Args_
-    } else {
-        & $python @Args_
-    }
+    & $python @Args_
 }
 
 $python = Find-Python

--- a/z.ps1
+++ b/z.ps1
@@ -1,0 +1,62 @@
+# Bootstrap wrapper for Nanvix build scripts.
+# Modeled on https://github.com/rust-lang/rust/blob/main/x.ps1
+
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# If script execution is disabled, run:
+#   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+#Requires -Version 5.1
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$MIN_MAJOR = 3
+$MIN_MINOR = 12
+
+function Find-Python {
+    $candidates = @("py", "python3", "python")
+    foreach ($candidate in $candidates) {
+        $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($null -eq $cmd) { continue }
+
+        # For 'py', pass -3 to select Python 3.
+        $pyArgs = if ($candidate -eq "py") { @("-3", "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") } `
+                  else { @("-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") }
+
+        try {
+            $version = & $candidate @pyArgs 2>$null
+            if ($LASTEXITCODE -ne 0) { continue }
+            $parts = $version.Trim().Split(".")
+            $major = [int]$parts[0]
+            $minor = [int]$parts[1]
+            if ($major -gt $MIN_MAJOR -or ($major -eq $MIN_MAJOR -and $minor -ge $MIN_MINOR)) {
+                return $candidate
+            }
+        } catch {
+            continue
+        }
+    }
+    return $null
+}
+
+$python = Find-Python
+if ($null -eq $python) {
+    Write-Error "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH."
+    Write-Host "hint:  Install Python 3.12+ and ensure it is on your PATH." -ForegroundColor Yellow
+    exit 3
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$zScript = Join-Path $scriptDir ".nanvix\z.py"
+
+if (-not (Test-Path $zScript)) {
+    Write-Error "error: $zScript not found."
+    Write-Host "hint:  Create .nanvix/z.py with a ZScript subclass." -ForegroundColor Yellow
+    exit 3
+}
+
+$pyArgs = if ($python -eq "py") { @("-3", $zScript) + $args } else { @($zScript) + $args }
+& $python @pyArgs
+exit $LASTEXITCODE

--- a/z.ps1
+++ b/z.ps1
@@ -43,7 +43,7 @@ function Find-Python {
 
 $python = Find-Python
 if ($null -eq $python) {
-    Write-Error "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH."
+    Write-Host "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH." -ForegroundColor Red
     Write-Host "hint:  Install Python 3.12+ and ensure it is on your PATH." -ForegroundColor Yellow
     exit 3
 }
@@ -52,7 +52,7 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $zScript = Join-Path $scriptDir ".nanvix\z.py"
 
 if (-not (Test-Path $zScript)) {
-    Write-Error "error: $zScript not found."
+    Write-Host "error: $zScript not found." -ForegroundColor Red
     Write-Host "hint:  Create .nanvix/z.py with a ZScript subclass." -ForegroundColor Yellow
     exit 3
 }

--- a/z.ps1
+++ b/z.ps1
@@ -16,7 +16,13 @@ $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
 function Find-Python {
-    $candidates = @("py", "python3", "python")
+    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
+    # then fall back to generic names.
+    $candidates = @()
+    for ($minor = 20; $minor -ge $MIN_MINOR; $minor--) {
+        $candidates += "python3.$minor"
+    }
+    $candidates += @("py", "python3", "python")
     foreach ($candidate in $candidates) {
         $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
         if ($null -eq $cmd) { continue }
@@ -49,7 +55,7 @@ if ($null -eq $python) {
 }
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$zScript = Join-Path $scriptDir ".nanvix\z.py"
+$zScript = Join-Path $scriptDir ".nanvix" "z.py"
 
 if (-not (Test-Path $zScript)) {
     Write-Host "error: $zScript not found." -ForegroundColor Red

--- a/z.ps1
+++ b/z.ps1
@@ -57,6 +57,9 @@ if (-not (Test-Path $zScript)) {
     exit 3
 }
 
-$pyArgs = if ($python -eq "py") { @("-3", $zScript) + $args } else { @($zScript) + $args }
-& $python @pyArgs
+if ($python -eq "py") {
+    & $python -3 $zScript @args
+} else {
+    & $python $zScript @args
+}
 exit $LASTEXITCODE

--- a/z.ps1
+++ b/z.ps1
@@ -19,9 +19,9 @@ $MIN_MINOR = 12
 $EXIT_MISSING_DEP = 3
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.1.1"
+$ZUTIL_TAG = "v0.2.0"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:d22dffb2e4efd8d4514edd8101ea74f496aea4b6b7bde1c972dce799f230a881"
+$ZUTIL_HASH = "sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,

--- a/z.ps1
+++ b/z.ps1
@@ -15,6 +15,11 @@ $ErrorActionPreference = "Stop"
 $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
+# nanvix-zutil release to install in the project venv.
+$ZUTIL_TAG = "v0.1.0"
+$ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
+$ZUTIL_HASH = "sha256:120d9bb4e409cf75ce823237812a414cd4ca90be8c421cad0c3583889a097497"
+
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
     # then fall back to generic names.
@@ -47,6 +52,16 @@ function Find-Python {
     return $null
 }
 
+# Run the discovered Python interpreter (handles 'py -3' on Windows).
+function Invoke-Python {
+    param([Parameter(ValueFromRemainingArguments)] [string[]]$Args_)
+    if ($python -eq "py") {
+        & $python -3 @Args_
+    } else {
+        & $python @Args_
+    }
+}
+
 $python = Find-Python
 if ($null -eq $python) {
     Write-Host "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH." -ForegroundColor Red
@@ -56,6 +71,13 @@ if ($null -eq $python) {
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $zScript = Join-Path $scriptDir ".nanvix" "z.py"
+$venvDir = Join-Path $scriptDir ".nanvix" "venv"
+$isWin = ($PSVersionTable.PSEdition -eq "Desktop") -or $IsWindows
+if ($isWin) {
+    $venvPython = Join-Path $venvDir "Scripts" "python.exe"
+} else {
+    $venvPython = Join-Path $venvDir "bin" "python"
+}
 
 if (-not (Test-Path $zScript)) {
     Write-Host "error: $zScript not found." -ForegroundColor Red
@@ -63,9 +85,29 @@ if (-not (Test-Path $zScript)) {
     exit 3
 }
 
-if ($python -eq "py") {
-    & $python -3 $zScript @args
-} else {
-    & $python $zScript @args
+# Bootstrap: create venv and install nanvix-zutil if needed.
+if (-not (Test-Path $venvPython)) {
+    Write-Host "bootstrap: creating venv …" -ForegroundColor Cyan
+    Invoke-Python -m venv $venvDir
+
+    $zutilPath = $env:NANVIX_ZUTIL_PATH
+    if ($zutilPath) {
+        Write-Host "bootstrap: installing nanvix-zutil (editable) …" -ForegroundColor Cyan
+        & $venvPython -m pip install -q -e $zutilPath
+    } else {
+        $version = $ZUTIL_TAG.TrimStart("v").Replace("-", "")
+        $whlName = "nanvix_zutil-${version}-py3-none-any.whl"
+        $whlUrl = "${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whlName}"
+        Write-Host "bootstrap: installing nanvix-zutil ($ZUTIL_TAG) …" -ForegroundColor Cyan
+        $tmpReq = [System.IO.Path]::GetTempFileName()
+        Set-Content -Path $tmpReq -Value "nanvix_zutil @ $whlUrl --hash=$ZUTIL_HASH"
+        try {
+            & $venvPython -m pip install -q --require-hashes -r $tmpReq
+        } finally {
+            Remove-Item -Path $tmpReq -ErrorAction SilentlyContinue
+        }
+    }
 }
+
+& $venvPython $zScript @args
 exit $LASTEXITCODE

--- a/z.ps1
+++ b/z.ps1
@@ -15,6 +15,9 @@ $ErrorActionPreference = "Stop"
 $MIN_MAJOR = 3
 $MIN_MINOR = 12
 
+# Exit codes (mirrors nanvix-zutil convention).
+$EXIT_MISSING_DEP = 3
+
 # nanvix-zutil release to install in the project venv.
 $ZUTIL_TAG = "v0.1.1"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
@@ -74,7 +77,7 @@ $python = Find-Python
 if ($null -eq $python) {
     Write-Warning "error: Python ${MIN_MAJOR}.${MIN_MINOR}+ not found in PATH."
     Write-Host "hint:  Install Python 3.12+ and ensure it is on your PATH." -ForegroundColor Yellow
-    exit 3
+    exit $EXIT_MISSING_DEP
 }
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -89,7 +92,7 @@ if ($IsWindows) {
 if (-not (Test-Path $zScript)) {
     Write-Warning "error: $zScript not found."
     Write-Host "hint:  Create .nanvix/z.py with a ZScript subclass." -ForegroundColor Yellow
-    exit 3
+    exit $EXIT_MISSING_DEP
 }
 
 # Bootstrap: create venv and install nanvix-zutil if needed.


### PR DESCRIPTION
Implement Phase 5 (first consumer) from the nanvix/zutils build schema.

New files:
- z            — Bash bootstrap wrapper (finds Python 3.12+, execs .nanvix/z.py)
- z.ps1        — PowerShell bootstrap wrapper (Windows equivalent)
- .nanvix/z.py — Consumer build script subclassing ZScript with:
  - Self-bootstrapping preamble (creates venv, installs nanvix-zutil)
  - setup()   — downloads Nanvix sysroot via nanvix_zutil.Sysroot
  - build()   — cross-compiles libz.a via Makefile.nanvix
  - test()    — runs smoke + integration + functional tests
  - release() — packages release tarball
  - clean()   — removes build artifacts

Updated:
- .gitignore  — excludes .nanvix/ build state (venv, cache, sysroot, env.json)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
