### PR TITLE
Update nanvix-zutil to v0.2.2, fix sysroot verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ example.elf
 .nanvix/sysroot/
 .nanvix/buildroot/
 .nanvix/env.json
+dist/

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -67,7 +67,7 @@ class ZlibBuild(ZScript):
             tag=tag,
             gh_token=self.config.get(CFG_GH_TOKEN),
         )
-        sysroot.verify(list(self.SYSROOT_REQUIRED_FILES))
+        sysroot.verify(self.sysroot_required_files())
         self.config.set(CFG_SYSROOT, str(sysroot.path))
         self.config.save()
 
@@ -76,12 +76,19 @@ class ZlibBuild(ZScript):
         self.run(*self._make_args("all"), cwd=self.repo_root)
 
     def test(self) -> None:
-        """Run the zlib test suite (smoke + integration + functional)."""
-        self.run(*self._make_args("test"), cwd=self.repo_root)
+        """Run the zlib test suite.
+
+        Without targets, runs the full suite (smoke + integration + functional).
+        With targets (e.g. ``./z test -- test-smoke test-integration``), passes
+        them directly to the Makefile.
+        """
+        targets = self.targets if self.targets else ["test"]
+        self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def release(self) -> None:
-        """Package the zlib release tarball."""
+        """Package the zlib release tarball and verify it."""
         self.run(*self._make_args("package"), cwd=self.repo_root)
+        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 
     def clean(self) -> None:
         """Remove build artifacts."""

--- a/z
+++ b/z
@@ -16,9 +16,9 @@ EXIT_GENERAL_ERROR=1
 EXIT_MISSING_DEP=3
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.2.0"
+ZUTIL_TAG="v0.2.2"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+ZUTIL_HASH="sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
 
 # Locate a suitable Python interpreter.
 find_python() {

--- a/z.ps1
+++ b/z.ps1
@@ -19,9 +19,9 @@ $MIN_MINOR = 12
 $EXIT_MISSING_DEP = 3
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.2.0"
+$ZUTIL_TAG = "v0.2.2"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+$ZUTIL_HASH = "sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,


### PR DESCRIPTION
## Summary

- Bump `z`/`z.ps1` bootstrap to nanvix-zutil v0.2.2 (targets passthrough, deployment-mode-aware sysroot verification)
- Fix `z.py`: use `sysroot_required_files()` instead of `SYSROOT_REQUIRED_FILES` (standalone no longer fails verifying multi-process-only files)
- Wire `self.targets` into `test()` so `./z test -- test-smoke test-integration` passes targets directly to the Makefile
- Add `verify-package` step to `release()`
- Add `dist/` to `.gitignore`

## Context

Prerequisite for the CI migration PR (#24), which will use `./z test -- test-smoke test-integration` for standalone mode instead of calling make directly.