### PR TITLE
Supersede #24: migrate CI to ./z and harden release SHA resolution

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages
+          apt-get update -qq && apt-get install -y -qq python3-pip
           ./z setup
 
       - name: Build

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -144,7 +144,28 @@ jobs:
           RELEASE_INFO=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$API_URL")
           NANVIX_NAME=$(echo "$RELEASE_INFO" | jq -r '.name // "latest"')
           NANVIX_PUBLISHED=$(echo "$RELEASE_INFO" | jq -r '.published_at')
-          NANVIX_SHA_FULL=$(echo "$RELEASE_INFO" | jq -r '.target_commitish // "unknown"')
+          NANVIX_TAG=$(echo "$RELEASE_INFO" | jq -r '.tag_name // empty')
+          NANVIX_TARGET=$(echo "$RELEASE_INFO" | jq -r '.target_commitish // empty')
+
+          # Resolve release ref to a full commit SHA.
+          REF="${NANVIX_TAG:-$NANVIX_TARGET}"
+          if [[ -z "$REF" ]]; then
+            echo "::error::Unable to determine Nanvix release ref"
+            exit 1
+          fi
+
+          if [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
+            NANVIX_SHA_FULL="$REF"
+          else
+            COMMIT_API_URL="https://api.github.com/repos/nanvix/nanvix/commits/${REF}"
+            NANVIX_SHA_FULL=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$COMMIT_API_URL" | jq -r '.sha // empty')
+          fi
+
+          if [[ -z "$NANVIX_SHA_FULL" || ! "$NANVIX_SHA_FULL" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Failed to resolve Nanvix ref '${REF}' to a commit SHA"
+            exit 1
+          fi
+
           NANVIX_SHA="${NANVIX_SHA_FULL::7}"
 
           echo "name=${NANVIX_NAME}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,42 +23,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
 
 jobs:
-  get-nanvix-info:
-    runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.extract.outputs.sha }}
-      sha_full: ${{ steps.extract.outputs.sha_full }}
-    steps:
-      - name: Download Nanvix Release Artifacts
-        id: extract
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Download all Nanvix release artifacts (authenticated to avoid API rate limits)
-          curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- --force nanvix-artifacts
-          # Find any artifact to extract the SHA
-          ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | head -1)
-          if [[ -z "$ARTIFACT_FILE" ]]; then
-            echo "::error::No Nanvix artifact found"
-            exit 1
-          fi
-          # Extract Nanvix commit SHA from artifact filename
-          NANVIX_SHA_FULL=$(basename "$ARTIFACT_FILE" | sed -E 's/.*-([a-f0-9]{40})\.tar\.bz2$/\1/')
-          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
-          echo "Nanvix commit SHA: $NANVIX_SHA_FULL (short: $NANVIX_SHA)"
-          echo "sha=$NANVIX_SHA" >> "$GITHUB_OUTPUT"
-          echo "sha_full=$NANVIX_SHA_FULL" >> "$GITHUB_OUTPUT"
-
-      - name: Upload Nanvix Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: nanvix-release-artifacts
-          path: nanvix-artifacts/*.tar.bz2
-          retention-days: 1
-
   build:
-    needs: get-nanvix-info
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -87,88 +52,63 @@ jobs:
       run:
         shell: bash
     env:
-      NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
-      NANVIX_SHA_FULL: ${{ needs.get-nanvix-info.outputs.sha_full }}
+      NANVIX_MACHINE: ${{ matrix.platform }}
+      NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
+      NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
       USER: runner
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Nanvix Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: nanvix-release-artifacts
-          path: nanvix-artifacts
-
-      - name: Extract Nanvix Release
+      - name: Setup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-          # Find and extract the artifact matching platform and process-mode
-          ARTIFACT_PATTERN="${{ matrix.platform }}.*${{ matrix.process-mode }}.*${{ matrix.memory }}.*\.tar\.bz2"
-          ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | grep -E "$ARTIFACT_PATTERN" | head -1)
-          if [[ -z "$ARTIFACT_FILE" ]]; then
-            echo "::error::No ${{ matrix.platform }} ${{ matrix.process-mode }} artifact found"
-            exit 1
-          fi
-          mkdir -p nanvix-artifacts/extracted
-          tar -xjf "$ARTIFACT_FILE" -C nanvix-artifacts/extracted
-          NANVIX_HOME=$(find nanvix-artifacts/extracted -maxdepth 2 -type d -name "bin" -exec dirname {} \; | head -1)
-          mkdir -p "$NANVIX_HOME/include"
-          echo "NANVIX_HOME=$NANVIX_HOME" >> "$GITHUB_ENV"
+          curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages
+          ./z setup
 
       - name: Build
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" all
+        run: ./z build
 
-      - name: Smoke Tests
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-smoke
-
-      - name: Integration Tests
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" test-integration
-
-      - name: Functional Tests
+      - name: Test
         if: matrix.process-mode != 'standalone'
-        run: |
-          timeout --foreground 300 make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PROCESS_MODE="${{ matrix.process-mode }}" test-functional
+        run: ./z test
 
-      - name: Package
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
-            MEMORY_SIZE="${{ matrix.memory }}" \
-            package
-          ARTIFACT_NAME="zlib-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}"
-          echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
+      - name: Test (standalone — smoke + integration only)
+        if: matrix.process-mode == 'standalone'
+        run: ./z test -- test-smoke test-integration
 
-      - name: Verify Package
-        run: |
-          make -f Makefile.nanvix CONFIG_NANVIX=y \
-            NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
-            PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
-            MEMORY_SIZE="${{ matrix.memory }}" \
-            verify-package
+      - name: Release
+        if: success()
+        run: ./z release
 
       - name: Upload Build Artifacts
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: zlib-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-          path: ${{ env.ARTIFACT_TARBALL }}
+          path: dist/*.tar.bz2
           retention-days: 7
 
+      - name: Collect failure logs
+        if: failure()
+        run: |
+          mkdir -p ci-logs
+          cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
+          find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
+          ls -lah ci-logs || true
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
+          path: ci-logs/*
+          if-no-files-found: warn
+
   release:
-    needs: [get-nanvix-info, build]
+    needs: [build]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    env:
-      NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
-      NANVIX_SHA_FULL: ${{ needs.get-nanvix-info.outputs.sha_full }}
     steps:
       - uses: actions/checkout@v4
 
@@ -191,18 +131,34 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+
+          # Verify we have release assets.
+          ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
+          if [[ "$ASSET_COUNT" -eq 0 ]]; then
+            echo "::error::No release assets found in release-assets/"
+            exit 1
+          fi
+
+          # Get Nanvix release metadata and SHA from the API.
           API_URL="https://api.github.com/repos/nanvix/nanvix/releases/tags/latest"
           RELEASE_INFO=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$API_URL")
           NANVIX_NAME=$(echo "$RELEASE_INFO" | jq -r '.name // "latest"')
           NANVIX_PUBLISHED=$(echo "$RELEASE_INFO" | jq -r '.published_at')
+          NANVIX_SHA_FULL=$(echo "$RELEASE_INFO" | jq -r '.target_commitish // "unknown"')
+          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
+
           echo "name=${NANVIX_NAME}" >> "$GITHUB_OUTPUT"
           echo "published=${NANVIX_PUBLISHED}" >> "$GITHUB_OUTPUT"
+          echo "sha=${NANVIX_SHA}" >> "$GITHUB_OUTPUT"
+          echo "sha_full=${NANVIX_SHA_FULL}" >> "$GITHUB_OUTPUT"
 
       - name: Create Latest Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NANVIX_NAME: ${{ steps.nanvix-release.outputs.name }}
           NANVIX_PUBLISHED: ${{ steps.nanvix-release.outputs.published }}
+          NANVIX_SHA: ${{ steps.nanvix-release.outputs.sha }}
+          NANVIX_SHA_FULL: ${{ steps.nanvix-release.outputs.sha_full }}
         run: |
           RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
           if gh release view "$RELEASE_TAG" &>/dev/null; then
@@ -239,13 +195,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${{ steps.nanvix-release.outputs.sha }}"
           echo "Triggering sqlite workflow..."
           gh api repos/nanvix/sqlite/dispatches \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -f event_type="zlib-release" \
-            -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
+            -f "client_payload[nanvix_sha]=${{ steps.nanvix-release.outputs.sha }}" \
             -f "client_payload[zlib_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger sqlite workflow"
 
   report-failure:

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ example.elf
 .nanvix/sysroot/
 .nanvix/buildroot/
 .nanvix/env.json
+dist/

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -67,7 +67,7 @@ class ZlibBuild(ZScript):
             tag=tag,
             gh_token=self.config.get(CFG_GH_TOKEN),
         )
-        sysroot.verify(list(self.SYSROOT_REQUIRED_FILES))
+        sysroot.verify(self.sysroot_required_files())
         self.config.set(CFG_SYSROOT, str(sysroot.path))
         self.config.save()
 
@@ -76,12 +76,19 @@ class ZlibBuild(ZScript):
         self.run(*self._make_args("all"), cwd=self.repo_root)
 
     def test(self) -> None:
-        """Run the zlib test suite (smoke + integration + functional)."""
-        self.run(*self._make_args("test"), cwd=self.repo_root)
+        """Run the zlib test suite.
+
+        Without targets, runs the full suite (smoke + integration + functional).
+        With targets (e.g. ``./z test -- test-smoke test-integration``), passes
+        them directly to the Makefile.
+        """
+        targets = self.targets if self.targets else ["test"]
+        self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def release(self) -> None:
-        """Package the zlib release tarball."""
+        """Package the zlib release tarball and verify it."""
         self.run(*self._make_args("package"), cwd=self.repo_root)
+        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 
     def clean(self) -> None:
         """Remove build artifacts."""

--- a/z
+++ b/z
@@ -16,9 +16,9 @@ EXIT_GENERAL_ERROR=1
 EXIT_MISSING_DEP=3
 
 # nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.2.0"
+ZUTIL_TAG="v0.2.2"
 ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+ZUTIL_HASH="sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
 
 # Locate a suitable Python interpreter.
 find_python() {

--- a/z.ps1
+++ b/z.ps1
@@ -19,9 +19,9 @@ $MIN_MINOR = 12
 $EXIT_MISSING_DEP = 3
 
 # nanvix-zutil release to install in the project venv.
-$ZUTIL_TAG = "v0.2.0"
+$ZUTIL_TAG = "v0.2.2"
 $ZUTIL_RELEASE_BASE = "https://github.com/nanvix/zutils/releases/download"
-$ZUTIL_HASH = "sha256:2d777cd93573e28bdfbfc978193a970b904fe564b82e17207b864a1221c7f0ca"
+$ZUTIL_HASH = "sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
 
 function Find-Python {
     # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,


### PR DESCRIPTION
## Summary
This PR supersedes #24.

It carries forward the CI migration work and includes the release metadata hardening updates needed to resolve outstanding review feedback.

## Supersedes
- #24

## Notes
- Please review this PR instead of #24.
