### PR TITLE
fix: Cache Nanvix CI artifacts to prevent release race condition

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -1,250 +1,259 @@
 name: Nanvix CI
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
-  push:
-    branches:
-      - nanvix/**
-  pull_request:
-    branches:
-      - nanvix/**
-  workflow_dispatch:
-  repository_dispatch:
-    types: [nanvix-minor-release, nanvix-major-release]
+    schedule:
+        - cron: "0 0 * * *"
+    push:
+        branches:
+            - nanvix/**
+    pull_request:
+        branches:
+            - nanvix/**
+    workflow_dispatch:
+    repository_dispatch:
+        types: [nanvix-minor-release, nanvix-major-release]
 
 permissions:
-  contents: write
-  actions: write
-  issues: write
+    contents: write
+    actions: write
+    issues: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}
-  cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
+    group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}
+    cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: hyperlight
-            process-mode: multi-process
-            memory: 128mb
-          - platform: hyperlight
-            process-mode: single-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: single-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: multi-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: standalone
-            memory: 128mb
-    name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-    container:
-      image: nanvix/toolchain:latest-minimal
-      options: --device /dev/kvm
-    defaults:
-      run:
-        shell: bash
-    env:
-      NANVIX_MACHINE: ${{ matrix.platform }}
-      NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
-      NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
-      USER: runner
-    steps:
-      - uses: actions/checkout@v4
+    get-nanvix-info:
+        runs-on: ubuntu-latest
+        outputs:
+            sha: ${{ steps.extract.outputs.sha }}
+            sha_full: ${{ steps.extract.outputs.sha_full }}
+        steps:
+            - name: Download Nanvix Release Artifacts
+              id: extract
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  # Download all Nanvix release artifacts (authenticated to avoid API rate limits)
+                  curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- --force nanvix-artifacts
+                  # Find any artifact to extract the SHA
+                  ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | head -1)
+                  if [[ -z "$ARTIFACT_FILE" ]]; then
+                    echo "::error::No Nanvix artifact found"
+                    exit 1
+                  fi
+                  # Extract Nanvix commit SHA from artifact filename
+                  NANVIX_SHA_FULL=$(basename "$ARTIFACT_FILE" | sed -E 's/.*-([a-f0-9]{40})\.tar\.bz2$/\1/')
+                  NANVIX_SHA="${NANVIX_SHA_FULL::7}"
+                  echo "Nanvix commit SHA: $NANVIX_SHA_FULL (short: $NANVIX_SHA)"
+                  echo "sha=$NANVIX_SHA" >> "$GITHUB_OUTPUT"
+                  echo "sha_full=$NANVIX_SHA_FULL" >> "$GITHUB_OUTPUT"
 
-      - name: Setup
+            - name: Upload Nanvix Artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: nanvix-release-artifacts
+                  path: nanvix-artifacts/*.tar.bz2
+                  retention-days: 1
+
+    build:
+        needs: [get-nanvix-info]
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - platform: hyperlight
+                      process-mode: multi-process
+                      memory: 128mb
+                    - platform: hyperlight
+                      process-mode: single-process
+                      memory: 128mb
+                    - platform: microvm
+                      process-mode: single-process
+                      memory: 128mb
+                    - platform: microvm
+                      process-mode: multi-process
+                      memory: 128mb
+                    - platform: microvm
+                      process-mode: standalone
+                      memory: 128mb
+        name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
+        container:
+            image: nanvix/toolchain:latest-minimal
+            options: --device /dev/kvm
+        defaults:
+            run:
+                shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          apt-get update -qq && apt-get install -y -qq python3-pip
-          ./z setup
+            NANVIX_MACHINE: ${{ matrix.platform }}
+            NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
+            NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
+            NANVIX_TAG: ${{ needs.get-nanvix-info.outputs.sha_full }}
+            USER: runner
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Build
-        run: ./z build
+            - name: Download Nanvix Artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: nanvix-release-artifacts
+                  path: nanvix-artifacts
 
-      - name: Test
-        if: matrix.process-mode != 'standalone'
-        run: ./z test
+            - name: Setup
+              run: |
+                  apt-get update -qq && apt-get install -y -qq python3-pip
+                  # Extract the correct artifact for this matrix configuration
+                  ASSET_PREFIX="nanvix-${{ matrix.platform }}-${{ matrix.process-mode }}-release-${{ matrix.memory }}"
+                  ARTIFACT=$(find nanvix-artifacts -maxdepth 1 -name "${ASSET_PREFIX}*.tar.bz2" | head -1)
+                  if [[ -z "$ARTIFACT" ]]; then
+                    echo "::error::No artifact matching '${ASSET_PREFIX}' found"
+                    ls -la nanvix-artifacts/
+                    exit 1
+                  fi
+                  echo "Using artifact: $ARTIFACT"
+                  mkdir -p .nanvix/sysroot
+                  tar -xjf "$ARTIFACT" -C .nanvix/sysroot
+                  # Sysroot is pre-placed; setup will verify and save config
+                  ./z setup
 
-      - name: Test (standalone — smoke + integration only)
-        if: matrix.process-mode == 'standalone'
-        run: ./z test -- test-smoke test-integration
+            - name: Build
+              run: ./z build
 
-      - name: Release
-        if: success()
-        run: ./z release
+            - name: Test
+              if: matrix.process-mode != 'standalone'
+              run: ./z test
 
-      - name: Upload Build Artifacts
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zlib-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-          path: dist/*.tar.bz2
-          retention-days: 7
+            - name: Test (standalone — smoke + integration only)
+              if: matrix.process-mode == 'standalone'
+              run: ./z test -- test-smoke test-integration
 
-      - name: Collect failure logs
-        if: failure()
-        run: |
-          mkdir -p ci-logs
-          cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
-          find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
-          ls -lah ci-logs || true
+            - name: Release
+              if: success()
+              run: ./z release
 
-      - name: Upload failure logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
-          path: ci-logs/*
-          if-no-files-found: warn
+            - name: Upload Build Artifacts
+              if: success()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: zlib-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
+                  path: dist/*.tar.bz2
+                  retention-days: 7
 
-  release:
-    needs: [build]
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+            - name: Collect failure logs
+              if: failure()
+              run: |
+                  mkdir -p ci-logs
+                  cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
+                  find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
+                  ls -lah ci-logs || true
 
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-artifacts
-          pattern: zlib-*
+            - name: Upload failure logs
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
+                  path: ci-logs/*
+                  if-no-files-found: warn
 
-      - name: Prepare Release Assets
-        run: |
-          set -euo pipefail
-          mkdir -p release-assets
-          find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \;
-          ls -la release-assets/
+    release:
+        needs: [get-nanvix-info, build]
+        if: github.event_name != 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Get Nanvix Release Info
-        id: nanvix-release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
+            - name: Download All Artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  path: release-artifacts
+                  pattern: zlib-*
 
-          # Verify we have release assets.
-          ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
-          if [[ "$ASSET_COUNT" -eq 0 ]]; then
-            echo "::error::No release assets found in release-assets/"
-            exit 1
-          fi
+            - name: Prepare Release Assets
+              run: |
+                  set -euo pipefail
+                  mkdir -p release-assets
+                  find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \;
+                  ls -la release-assets/
 
-          # Get Nanvix release metadata and SHA from the API.
-          API_URL="https://api.github.com/repos/nanvix/nanvix/releases/tags/latest"
-          RELEASE_INFO=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$API_URL")
-          NANVIX_NAME=$(echo "$RELEASE_INFO" | jq -r '.name // "latest"')
-          NANVIX_PUBLISHED=$(echo "$RELEASE_INFO" | jq -r '.published_at')
-          NANVIX_TAG=$(echo "$RELEASE_INFO" | jq -r '.tag_name // empty')
-          NANVIX_TARGET=$(echo "$RELEASE_INFO" | jq -r '.target_commitish // empty')
+            - name: Verify Release Assets
+              run: |
+                  set -euo pipefail
+                  ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
+                  if [[ "$ASSET_COUNT" -eq 0 ]]; then
+                    echo "::error::No release assets found in release-assets/"
+                    exit 1
+                  fi
 
-          # Resolve release ref to a full commit SHA.
-          REF="${NANVIX_TAG:-$NANVIX_TARGET}"
-          if [[ -z "$REF" ]]; then
-            echo "::error::Unable to determine Nanvix release ref"
-            exit 1
-          fi
+            - name: Create Latest Release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.sha }}
+                  NANVIX_SHA_FULL: ${{ needs.get-nanvix-info.outputs.sha_full }}
+              run: |
+                  RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+                  if gh release view "$RELEASE_TAG" &>/dev/null; then
+                    gh release delete "$RELEASE_TAG" --yes --cleanup-tag || true
+                  fi
+                  gh release create "$RELEASE_TAG" \
+                    --title "Build ${GITHUB_SHA::7}" \
+                    --notes "Automated build from branch ${{ github.ref_name }} at commit ${{ github.sha }}.
 
-          if [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
-            NANVIX_SHA_FULL="$REF"
-          else
-            COMMIT_API_URL="https://api.github.com/repos/nanvix/nanvix/commits/${REF}"
-            NANVIX_SHA_FULL=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$COMMIT_API_URL" | jq -r '.sha // empty')
-          fi
+                  **Build Information:**
+                  - Workflow Run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+                  - Commit: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+                  - Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
 
-          if [[ -z "$NANVIX_SHA_FULL" || ! "$NANVIX_SHA_FULL" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Failed to resolve Nanvix ref '${REF}' to a commit SHA"
-            exit 1
-          fi
+                  **Nanvix Release:**
+                  - Commit: [${NANVIX_SHA_FULL}](https://github.com/nanvix/nanvix/commit/${NANVIX_SHA_FULL})
 
-          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
+                  **Package Layout:**
+                  \`\`\`
+                  sysroot/
+                    lib/libz.a
+                    include/{zlib.h,zconf.h}
+                    bin/{example.elf,minigzip.elf}
+                  \`\`\`
 
-          echo "name=${NANVIX_NAME}" >> "$GITHUB_OUTPUT"
-          echo "published=${NANVIX_PUBLISHED}" >> "$GITHUB_OUTPUT"
-          echo "sha=${NANVIX_SHA}" >> "$GITHUB_OUTPUT"
-          echo "sha_full=${NANVIX_SHA_FULL}" >> "$GITHUB_OUTPUT"
+                  **Dependencies:** None (standalone library)" \
+                    --latest \
+                    release-assets/*.tar.bz2
 
-      - name: Create Latest Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NANVIX_NAME: ${{ steps.nanvix-release.outputs.name }}
-          NANVIX_PUBLISHED: ${{ steps.nanvix-release.outputs.published }}
-          NANVIX_SHA: ${{ steps.nanvix-release.outputs.sha }}
-          NANVIX_SHA_FULL: ${{ steps.nanvix-release.outputs.sha_full }}
-        run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
-          if gh release view "$RELEASE_TAG" &>/dev/null; then
-            gh release delete "$RELEASE_TAG" --yes --cleanup-tag || true
-          fi
-          gh release create "$RELEASE_TAG" \
-            --title "Build ${GITHUB_SHA::7}" \
-            --notes "Automated build from branch ${{ github.ref_name }} at commit ${{ github.sha }}.
+            - name: Trigger Dependent Workflows
+              if: success()
+              env:
+                  GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+              run: |
+                  RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${{ needs.get-nanvix-info.outputs.sha }}"
+                  echo "Triggering sqlite workflow..."
+                  gh api repos/nanvix/sqlite/dispatches \
+                    -X POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -f event_type="zlib-release" \
+                    -f "client_payload[nanvix_sha]=${{ needs.get-nanvix-info.outputs.sha }}" \
+                    -f "client_payload[zlib_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger sqlite workflow"
 
-          **Build Information:**
-          - Workflow Run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          - Commit: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
-          - Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-
-          **Nanvix Release:**
-          - Name: ${NANVIX_NAME}
-          - Published: ${NANVIX_PUBLISHED}
-          - Commit: [${NANVIX_SHA_FULL}](https://github.com/nanvix/nanvix/commit/${NANVIX_SHA_FULL})
-
-          **Package Layout:**
-          \`\`\`
-          sysroot/
-            lib/libz.a
-            include/{zlib.h,zconf.h}
-            bin/{example.elf,minigzip.elf}
-          \`\`\`
-
-          **Dependencies:** None (standalone library)" \
-            --latest \
-            release-assets/*.tar.bz2
-
-      - name: Trigger Dependent Workflows
-        if: success()
-        env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-        run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${{ steps.nanvix-release.outputs.sha }}"
-          echo "Triggering sqlite workflow..."
-          gh api repos/nanvix/sqlite/dispatches \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -f event_type="zlib-release" \
-            -f "client_payload[nanvix_sha]=${{ steps.nanvix-release.outputs.sha }}" \
-            -f "client_payload[zlib_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger sqlite workflow"
-
-  report-failure:
-    needs: [build]
-    if: >-
-      ${{ always() &&
-          (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
-          needs.build.result == 'failure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create failure issue
-        uses: actions/github-script@v7
-        env:
-          BUILD_RESULT: ${{ needs.build.result }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `CI failure (run ${context.runNumber})`,
-              body: `The zlib CI workflow failed.\n- Trigger: ${context.eventName}\n- Run: [#${context.runNumber}](${runUrl})\n- SHA: ${context.sha}\n- build: ${process.env.BUILD_RESULT}\n\nPlease investigate.`,
-              assignees: ['ppenna']
-            });
+    report-failure:
+        needs: [build]
+        if: >-
+            ${{ always() &&
+                (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
+                needs.build.result == 'failure' }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Create failure issue
+              uses: actions/github-script@v7
+              env:
+                  BUILD_RESULT: ${{ needs.build.result }}
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      await github.rest.issues.create({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        title: `CI failure (run ${context.runNumber})`,
+                        body: `The zlib CI workflow failed.\n- Trigger: ${context.eventName}\n- Run: [#${context.runNumber}](${runUrl})\n- SHA: ${context.sha}\n- build: ${process.env.BUILD_RESULT}\n\nPlease investigate.`,
+                        assignees: ['ppenna']
+                      });


### PR DESCRIPTION
## Summary

Refactors the Nanvix CI workflow to eliminate a race condition where parallel matrix build jobs each independently fetched Nanvix release metadata and artifacts. If the upstream Nanvix release changed mid-workflow, different matrix jobs could build against different Nanvix commits, producing inconsistent artifacts.

## Changes

- **New `get-nanvix-info` job**: Downloads Nanvix release artifacts once at the start of the workflow, extracts the commit SHA from the artifact filename, and uploads them as a GitHub Actions artifact for downstream jobs.
- **`build` jobs consume cached artifacts**: Each matrix job now downloads the pre-fetched Nanvix artifacts instead of independently resolving the Nanvix release. The correct platform-specific artifact is extracted and placed into the sysroot.
- **`release` job uses cached SHA**: The Nanvix commit SHA is passed via job outputs from `get-nanvix-info` instead of re-querying the GitHub API, removing the redundant `Get Nanvix Release Info` step.
- **YAML reformatted** to 4-space indentation for consistency.

## Motivation

The previous workflow had each of the 5 matrix build jobs independently call the Nanvix release API and download artifacts. This created two problems:

1. **Race condition**: If the Nanvix `latest` release was updated while the workflow was running, different matrix jobs could resolve to different commits.
2. **Redundant API calls**: The same release metadata and artifacts were fetched 5+ times per workflow run.

The new design fetches artifacts exactly once and fans them out via GitHub Actions artifact caching.
