### PR TITLE
ci: add hyperlight-standalone-128mb to CI matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,22 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: hyperlight
-            process-mode: multi-process
-            memory: 128mb
-          - platform: hyperlight
-            process-mode: single-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: single-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: multi-process
-            memory: 128mb
-          - platform: microvm
-            process-mode: standalone
-            memory: 128mb
+        platform: [hyperlight, microvm]
+        process-mode: [multi-process, single-process, standalone]
+        memory: [128mb]
     name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
     container:
       image: nanvix/toolchain:latest-minimal


### PR DESCRIPTION
Add the missing `hyperlight + standalone + 128mb` matrix entry to `nanvix-ci.yml` so that CI covers all 6 of the 128mb images published by Nanvix.

## Changes

- Added new matrix entry: `hyperlight + standalone + 128mb`
- No entries removed — all existing entries remain unchanged

## Matrix (6 entries)

| Platform | Process Mode | Memory |
|---|---|---|
| hyperlight | multi-process | 128mb |
| hyperlight | single-process | 128mb |
| **hyperlight** | **standalone** | **128mb** |
| microvm | single-process | 128mb |
| microvm | multi-process | 128mb |
| microvm | standalone | 128mb |