### PR TITLE
[ci] Migrate to nanvix-zutil CLI

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -1,14 +1,15 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
 name: Nanvix CI
 
 on:
   schedule:
     - cron: "0 0 * * *"
   push:
-    branches:
-      - nanvix/**
+    branches: ["nanvix/**"]
   pull_request:
-    branches:
-      - nanvix/**
+    branches: ["nanvix/**"]
   workflow_dispatch:
   repository_dispatch:
     types: [nanvix-minor-release, nanvix-major-release]
@@ -22,8 +23,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name || github.ref || 'default' }}
   cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
 
+env:
+  NANVIX_ZUTIL_VERSION: v0.4.0
+
 jobs:
+  get-nanvix-info:
+    name: Get Nanvix Info
+    runs-on: ubuntu-latest
+    outputs:
+      nanvix_tag: ${{ steps.resolve.outputs.nanvix_tag }}
+      nanvix_sha: ${{ steps.resolve.outputs.nanvix_sha }}
+      nanvix_version: ${{ steps.resolve.outputs.nanvix_version }}
+      package_name: ${{ steps.resolve.outputs.package_name }}
+      package_version: ${{ steps.resolve.outputs.package_version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install nanvix-zutil
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          WHEEL_URL=$(gh api repos/nanvix/zutils/releases/tags/"$NANVIX_ZUTIL_VERSION" \
+            --jq '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
+          python3 -m pip install "$WHEEL_URL"
+
+      - name: Resolve lockfile and extract release info
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: nanvix-zutil resolve >> "$GITHUB_OUTPUT"
+
   build:
+    needs: get-nanvix-info
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -42,16 +73,27 @@ jobs:
       NANVIX_MACHINE: ${{ matrix.platform }}
       NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
       NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
+      NANVIX_VERSION: ${{ needs.get-nanvix-info.outputs.nanvix_tag }}
       USER: runner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
+      - name: Install gh CLI and pip
+        run: |
+          apt-get update -qq && apt-get install -y -qq gh python3-pip
+
+      - name: Install nanvix-zutil
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          WHEEL_URL=$(gh api repos/nanvix/zutils/releases/tags/"$NANVIX_ZUTIL_VERSION" \
+            --jq '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
+          python3 -m pip install --break-system-packages "$WHEEL_URL"
 
       - name: Setup
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          apt-get update -qq && apt-get install -y -qq python3-pip
-          ./z setup
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: ./z setup
 
       - name: Build
         run: ./z build
@@ -68,11 +110,11 @@ jobs:
         if: success()
         run: ./z release
 
-      - name: Upload Build Artifacts
+      - name: Upload build artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
-          name: zlib-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
+          name: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
           path: dist/*.tar.bz2
           retention-days: 7
 
@@ -82,153 +124,107 @@ jobs:
           mkdir -p ci-logs
           cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
           find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
-          ls -lah ci-logs || true
 
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
           path: ci-logs/*
           if-no-files-found: warn
 
   release:
-    needs: [build]
+    needs: [get-nanvix-info, build]
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Download All Artifacts
+      - name: Download all build artifacts
         id: download-artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         continue-on-error: true
         with:
           path: release-artifacts
-          pattern: zlib-*
+          pattern: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-*
 
-      - name: Prepare Release Assets
+      - name: Prepare release assets
         run: |
           set -euo pipefail
           mkdir -p release-assets
           if [[ "${{ steps.download-artifacts.outcome }}" == "failure" ]]; then
-            echo "::warning::Artifact download step failed — this may indicate an API or network issue"
+            echo "::warning::Artifact download failed — possible API or network issue"
           fi
           find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \; 2>/dev/null || true
           ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
           echo "Found $ASSET_COUNT release asset(s)"
           if [[ "$ASSET_COUNT" -eq 0 ]]; then
-            echo "::error::No release assets found — all matrix builds may have failed or artifact retrieval encountered an error"
+            echo "::error::No release assets found — all matrix builds may have failed"
             exit 1
           fi
           ls -la release-assets/
 
-      - name: Get Nanvix Release Info
-        id: nanvix-release
+      - name: Generate lockfile
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          WHEEL_URL=$(gh api repos/nanvix/zutils/releases/tags/"$NANVIX_ZUTIL_VERSION" \
+            --jq '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
+          python3 -m pip install "$WHEEL_URL"
+          nanvix-zutil resolve > /dev/null  # validate manifest resolves
+          nanvix-zutil lock --shallow
+          cp .nanvix/nanvix.lock release-assets/nanvix.lock
 
-          # Get Nanvix release metadata and SHA from the API.
-          API_URL="https://api.github.com/repos/nanvix/nanvix/releases/tags/latest"
-          RELEASE_INFO=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$API_URL")
-          NANVIX_NAME=$(echo "$RELEASE_INFO" | jq -r '.name // "latest"')
-          NANVIX_PUBLISHED=$(echo "$RELEASE_INFO" | jq -r '.published_at')
-          NANVIX_TAG=$(echo "$RELEASE_INFO" | jq -r '.tag_name // empty')
-          NANVIX_TARGET=$(echo "$RELEASE_INFO" | jq -r '.target_commitish // empty')
-
-          # Resolve release ref to a full commit SHA.
-          REF="${NANVIX_TAG:-$NANVIX_TARGET}"
-          if [[ -z "$REF" ]]; then
-            echo "::error::Unable to determine Nanvix release ref"
-            exit 1
-          fi
-
-          if [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
-            NANVIX_SHA_FULL="$REF"
-          else
-            COMMIT_API_URL="https://api.github.com/repos/nanvix/nanvix/commits/${REF}"
-            NANVIX_SHA_FULL=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "$COMMIT_API_URL" | jq -r '.sha // empty')
-          fi
-
-          if [[ -z "$NANVIX_SHA_FULL" || ! "$NANVIX_SHA_FULL" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::Failed to resolve Nanvix ref '${REF}' to a commit SHA"
-            exit 1
-          fi
-
-          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
-
-          echo "name=${NANVIX_NAME}" >> "$GITHUB_OUTPUT"
-          echo "published=${NANVIX_PUBLISHED}" >> "$GITHUB_OUTPUT"
-          echo "sha=${NANVIX_SHA}" >> "$GITHUB_OUTPUT"
-          echo "sha_full=${NANVIX_SHA_FULL}" >> "$GITHUB_OUTPUT"
-
-      - name: Create Latest Release
+      - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NANVIX_NAME: ${{ steps.nanvix-release.outputs.name }}
-          NANVIX_PUBLISHED: ${{ steps.nanvix-release.outputs.published }}
-          NANVIX_SHA: ${{ steps.nanvix-release.outputs.sha }}
-          NANVIX_SHA_FULL: ${{ steps.nanvix-release.outputs.sha_full }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+          RELEASE_TAG="${{ needs.get-nanvix-info.outputs.package_version }}-nanvix-${{ needs.get-nanvix-info.outputs.nanvix_version }}"
+
+          # Idempotency: skip if release already exists
           if gh release view "$RELEASE_TAG" &>/dev/null; then
-            gh release delete "$RELEASE_TAG" --yes --cleanup-tag || true
+            echo "Release $RELEASE_TAG already exists — skipping"
+            exit 0
           fi
+
           gh release create "$RELEASE_TAG" \
             --title "Build ${GITHUB_SHA::7}" \
-            --notes "Automated build from branch ${{ github.ref_name }} at commit ${{ github.sha }}.
+            --notes "Automated build from branch ${{ github.ref_name }}.
 
-          **Build Information:**
-          - Workflow Run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          - Commit: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
-          - Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-
-          **Nanvix Release:**
-          - Name: ${NANVIX_NAME}
-          - Published: ${NANVIX_PUBLISHED}
-          - Commit: [${NANVIX_SHA_FULL}](https://github.com/nanvix/nanvix/commit/${NANVIX_SHA_FULL})
-
-          **Package Layout:**
-          \`\`\`
-          sysroot/
-            lib/libz.a
-            include/{zlib.h,zconf.h}
-            bin/{example.elf,minigzip.elf}
-          \`\`\`
-
-          **Dependencies:** None (standalone library)" \
+          **Build:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          **Commit:** [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          **Nanvix:** [${{ needs.get-nanvix-info.outputs.nanvix_sha }}](https://github.com/nanvix/nanvix/commit/${{ needs.get-nanvix-info.outputs.nanvix_sha }})" \
             --latest \
-            release-assets/*.tar.bz2
+            release-assets/*
 
-      - name: Trigger Dependent Workflows
+      - name: Trigger dependent workflows
         if: success()
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${{ steps.nanvix-release.outputs.sha }}"
+          RELEASE_TAG="${{ needs.get-nanvix-info.outputs.package_version }}-nanvix-${{ needs.get-nanvix-info.outputs.nanvix_version }}"
           echo "Triggering sqlite workflow..."
           gh api repos/nanvix/sqlite/dispatches \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -f event_type="zlib-release" \
-            -f "client_payload[nanvix_sha]=${{ steps.nanvix-release.outputs.sha }}" \
+            -f "client_payload[nanvix_version]=${{ needs.get-nanvix-info.outputs.nanvix_version }}" \
             -f "client_payload[zlib_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger sqlite workflow"
 
   report-failure:
     needs: [build, release]
     if: >-
       ${{ always() &&
-          (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
-          needs.build.result == 'failure' &&
-          needs.release.result == 'failure' }}
+          (github.event_name == 'push' ||
+           github.event_name == 'schedule' ||
+           github.event_name == 'repository_dispatch') &&
+          (needs.build.result == 'failure' ||
+           needs.release.result == 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - name: Report failure issue
-        uses: actions/github-script@v7
-        env:
-          BUILD_RESULT: ${{ needs.build.result }}
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -237,13 +233,12 @@ jobs:
             const repo = context.repo.repo;
             const title = `CI failure`;
             const body = [
-              `The zlib CI workflow failed.`,
+              `CI workflow failed.`,
               `- Trigger: ${context.eventName}`,
               `- Run: [#${context.runNumber}](${runUrl})`,
               `- SHA: ${context.sha}`,
-              `- build: ${process.env.BUILD_RESULT}`,
               '',
-              'Please investigate and take any corrective actions.'
+              'Please investigate and take corrective action.'
             ].join('\n');
 
             const { data: search } = await github.rest.search.issuesAndPullRequests({
@@ -252,13 +247,22 @@ jobs:
             const existing = search.items.find(i => i.title === title);
 
             if (existing) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number, body
+              });
+
+              // Reconcile assignees: add any missing desired assignees.
               const currentAssignees = existing.assignees.map(a => a.login);
               const desired = ['ppenna', 'danbugs'];
               const missing = desired.filter(a => !currentAssignees.includes(a));
               if (missing.length > 0) {
-                await github.rest.issues.addAssignees({ owner, repo, issue_number: existing.number, assignees: missing });
+                await github.rest.issues.addAssignees({
+                  owner, repo, issue_number: existing.number, assignees: missing
+                });
               }
             } else {
-              await github.rest.issues.create({ owner, repo, title, body, assignees: ['ppenna', 'danbugs'] });
+              await github.rest.issues.create({
+                owner, repo, title, body,
+                assignees: ['ppenna', 'danbugs']
+              });
             }

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,0 +1,4 @@
+[package]
+name = "zlib"
+version = "1.3.1"
+nanvix-version = "latest"

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,7 +11,7 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
-from nanvix_zutil import CFG_GH_TOKEN, CFG_SYSROOT, CFG_TAG, CFG_TOOLCHAIN, EXIT_MISSING_DEP, Sysroot, ZScript, log
+from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
@@ -24,8 +24,6 @@ _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
 class ZlibBuild(ZScript):
     """Build script for nanvix/zlib."""
-
-    NANVIX_TAG = "latest"
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""
@@ -56,20 +54,7 @@ class ZlibBuild(ZScript):
 
     def setup(self) -> None:
         """Download the Nanvix sysroot."""
-        tag = self.config.get(CFG_TAG, self.NANVIX_TAG)
-        if not tag:
-            log.fatal(f"{CFG_TAG} is not set.", code=EXIT_MISSING_DEP)
-
-        sysroot = Sysroot.download(
-            machine=self.config.machine,
-            deployment_mode=self.config.deployment_mode,
-            memory_size=self.config.memory_size,
-            tag=tag,
-            gh_token=self.config.get(CFG_GH_TOKEN),
-        )
-        sysroot.verify(self.sysroot_required_files())
-        self.config.set(CFG_SYSROOT, str(sysroot.path))
-        self.config.save()
+        super().setup()
 
     def build(self) -> None:
         """Cross-compile libz.a for Nanvix."""

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -40,6 +40,26 @@ This document describes the port of [zlib](https://zlib.net/) compression librar
 For experienced users who want to build quickly:
 
 ```bash
+# 1. Install nanvix-zutil (requires gh CLI: https://cli.github.com)
+#    Using a venv is recommended on modern Linux distros (PEP 668).
+python3 -m venv .venv && source .venv/bin/activate
+WHEEL_URL=$(gh api repos/nanvix/zutils/releases/latest \
+  --jq '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
+pip install "$WHEEL_URL"
+
+# 2. Setup (downloads Nanvix sysroot automatically)
+./z setup
+
+# 3. Build
+./z build
+
+# 4. Run tests
+./z test
+```
+
+Or build directly with Make (advanced):
+
+```bash
 # 1. Pull the Docker image
 docker pull nanvix/toolchain:latest-minimal
 
@@ -61,12 +81,13 @@ Continue reading for detailed instructions.
 
 ## Prerequisites
 
-You need two components to build zlib for Nanvix:
+You need the following to build zlib for Nanvix:
 
-| Component | Description | Default Location |
-|-----------|-------------|------------------|
-| **Nanvix Toolchain** | i686-nanvix cross-compiler | `$HOME/toolchain` |
-| **Nanvix Sysroot** | System libraries and linker script | `$HOME/nanvix` |
+| Component | Description | Install |
+|-----------|-------------|---------|
+| **nanvix-zutil** | Build orchestration CLI | `pip install` from [GitHub Releases](https://github.com/nanvix/zutils/releases) |
+| **Nanvix Toolchain** | i686-nanvix cross-compiler | Docker image or native install |
+| **Nanvix Sysroot** | System libraries and linker script | `nanvix-zutil setup` |
 
 ### Available Platform Configurations
 
@@ -74,8 +95,10 @@ You need two components to build zlib for Nanvix:
 |----------|--------------|------------------|
 | hyperlight | multi-process | `hyperlight.*multi-process` |
 | hyperlight | single-process | `hyperlight.*single-process` |
-| microvm | single-process | `microvm.*single-process` |
+| hyperlight | standalone | `hyperlight.*standalone` |
 | microvm | multi-process | `microvm.*multi-process` |
+| microvm | single-process | `microvm.*single-process` |
+| microvm | standalone | `microvm.*standalone` |
 
 ### Downloading Nanvix
 
@@ -89,7 +112,21 @@ The script downloads all release artifacts. Extract the one matching your target
 
 ## Building
 
-### Using Docker (Recommended)
+### Using nanvix-zutil (Recommended)
+
+```bash
+# Install nanvix-zutil (use a venv on modern Linux distros)
+python3 -m venv .venv && source .venv/bin/activate
+WHEEL_URL=$(gh api repos/nanvix/zutils/releases/latest \
+  --jq '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
+pip install "$WHEEL_URL"
+
+# Setup sysroot and build
+./z setup
+./z build
+```
+
+### Using Docker (Direct Make)
 
 The Makefile supports automatic Docker fallback when the native toolchain is not available:
 
@@ -137,6 +174,15 @@ After a successful build, you will have:
 
 ```bash
 # Run all tests
+./z test
+
+# Or run specific test targets
+./z test -- test-smoke test-integration
+```
+
+Alternatively, invoke Make directly:
+
+```bash
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix test
 ```
 
@@ -178,6 +224,11 @@ The following changes were made to support Nanvix.
 |------|---------|
 | `Makefile.nanvix` | Standalone Makefile for Nanvix cross-compilation |
 | `NANVIX.md` | This documentation file |
+| `z` | Unified entry point (delegates to `z.sh` or `z.ps1`) |
+| `z.sh` | Bash wrapper that delegates to `nanvix-zutil` CLI |
+| `z.ps1` | PowerShell wrapper that delegates to `nanvix-zutil` CLI |
+| `.nanvix/z.py` | Build script (extends `nanvix-zutil` `ZScript`) |
+| `.nanvix/nanvix.toml` | Package manifest for dependency resolution |
 | `.github/workflows/nanvix-ci.yml` | CI workflow for automated builds |
 
 ### Source Code Changes
@@ -199,7 +250,16 @@ The following changes were made to support Nanvix.
 
 ## CI/CD
 
-The GitHub Actions workflow at `.github/workflows/nanvix-ci.yml` automates building and testing on every change.
+The GitHub Actions workflow at `.github/workflows/nanvix-ci.yml` automates building and testing on every change. It uses the `nanvix-zutil` CLI (installed from the wheel in GitHub Releases) for all build orchestration.
+
+### Workflow Structure
+
+| Job | Description |
+|-----|-------------|
+| `get-nanvix-info` | Resolves the manifest and extracts Nanvix version metadata |
+| `build` | Cross-compiles, tests, and packages across the build matrix |
+| `release` | Creates a GitHub release with build artifacts and lockfile |
+| `report-failure` | Opens/updates a GitHub issue on CI failures |
 
 ### Trigger Events
 
@@ -209,18 +269,20 @@ The GitHub Actions workflow at `.github/workflows/nanvix-ci.yml` automates build
 | PR to `nanvix/**` | Pull requests targeting Nanvix branches |
 | Daily schedule | Runs at midnight UTC |
 | Manual dispatch | Can be triggered manually |
-| Repository dispatch | Triggered by `nanvix-release` events |
+| Repository dispatch | Triggered by `nanvix-minor-release` or `nanvix-major-release` events |
 
 ### Build Matrix
 
-The CI runs on 4 different platform/process-mode configurations:
+The CI runs on 6 different platform/process-mode configurations:
 
-| Platform | Process Mode | Runner |
-|----------|--------------|--------|
-| hyperlight | multi-process | `self-hosted-hyperlight-multi` |
-| hyperlight | single-process | `self-hosted-hyperlight-single` |
-| microvm | single-process | `self-hosted-microvm-single` |
-| microvm | multi-process | `self-hosted-microvm-multi` |
+| Platform | Process Mode |
+|----------|--------------|
+| hyperlight | multi-process |
+| hyperlight | single-process |
+| hyperlight | standalone |
+| microvm | multi-process |
+| microvm | single-process |
+| microvm | standalone |
 
 All configurations run in parallel with `fail-fast: false`, ensuring that all platforms are tested even if one fails.
 

--- a/z
+++ b/z
@@ -1,119 +1,20 @@
 #!/usr/bin/env bash
-# Bootstrap wrapper for Nanvix build scripts.
-# Modeled on https://github.com/rust-lang/rust/blob/main/x
-
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
+# Unified entry point: delegates to z.sh (Linux/macOS) or z.ps1 (Windows).
+# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+
 set -euo pipefail
 
-# Minimum required Python version.
-MIN_PYTHON_MAJOR=3
-MIN_PYTHON_MINOR=12
-
-# Exit codes (mirrors nanvix-zutil convention).
-EXIT_GENERAL_ERROR=1
-EXIT_MISSING_DEP=3
-
-# nanvix-zutil release to install in the project venv.
-ZUTIL_TAG="v0.2.2"
-ZUTIL_RELEASE_BASE="https://github.com/nanvix/zutils/releases/download"
-ZUTIL_HASH="sha256:dc28bb5b83fe0afebb89a3b02b334d4753ba362328d5b4f32f79c2cb8df6ba8a"
-
-# Locate a suitable Python interpreter.
-find_python() {
-    # Prefer version-suffixed interpreters (e.g., python3.12, python3.13) first,
-    # then fall back to generic names.
-    local candidates=()
-    local minor
-    for ((minor=20; minor>=MIN_PYTHON_MINOR; minor--)); do
-        candidates+=("python3.${minor}")
-    done
-    candidates+=("python3" "python" "py")
-    for candidate in "${candidates[@]}"; do
-        if command -v "${candidate}" &>/dev/null; then
-            local version
-            if [[ "${candidate}" == "py" ]]; then
-                version=$("${candidate}" -3 -c \
-                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
-                    2>/dev/null) || continue
-            else
-                version=$("${candidate}" -c \
-                    "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" \
-                    2>/dev/null) || continue
-            fi
-            local major minor
-            major=$(echo "${version}" | tr -d '\r' | cut -d. -f1)
-            minor=$(echo "${version}" | tr -d '\r' | cut -d. -f2)
-            if [[ "${major}" -gt "${MIN_PYTHON_MAJOR}" ]] || \
-               [[ "${major}" -eq "${MIN_PYTHON_MAJOR}" && "${minor}" -ge "${MIN_PYTHON_MINOR}" ]]; then
-                echo "${candidate}"
-                return 0
-            fi
-        fi
-    done
-    return "${EXIT_GENERAL_ERROR}"
-}
-
-# Run the discovered Python interpreter (handles 'py -3' on Windows).
-run_python() {
-    if [[ "${PYTHON}" == "py" ]]; then
-        "${PYTHON}" -3 "$@"
-    else
-        "${PYTHON}" "$@"
-    fi
-}
-
-PYTHON=$(find_python) || {
-    echo "error: Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ not found in PATH." >&2
-    echo "hint:  Install Python 3.12+ and ensure it is on your PATH." >&2
-    exit "${EXIT_MISSING_DEP}"
-}
-
-# Resolve the directory containing this script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-Z_SCRIPT="${SCRIPT_DIR}/.nanvix/z.py"
-VENV_DIR="${SCRIPT_DIR}/.nanvix/venv"
 
-# Detect venv interpreter path (Scripts/python.exe on Windows/MSYS).
-if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
-    VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
-else
-    VENV_PYTHON="${VENV_DIR}/bin/python"
-fi
-
-if [[ ! -f "${Z_SCRIPT}" ]]; then
-    echo "error: ${Z_SCRIPT} not found." >&2
-    echo "hint:  Create .nanvix/z.py with a ZScript subclass." >&2
-    exit "${EXIT_MISSING_DEP}"
-fi
-
-# Bootstrap: create venv and install nanvix-zutil if needed.
-if [[ ! -f "${VENV_PYTHON}" ]]; then
-    echo "bootstrap: creating venv …" >&2
-    run_python -m venv "${VENV_DIR}"
-
-    # Re-detect after venv creation.
-    if [[ -f "${VENV_DIR}/Scripts/python.exe" ]]; then
-        VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
-    fi
-
-    if [[ -n "${NANVIX_ZUTIL_PATH:-}" ]]; then
-        echo "bootstrap: installing nanvix-zutil (editable) …" >&2
-        "${VENV_PYTHON}" -m pip install -q -e "${NANVIX_ZUTIL_PATH}"
-    else
-        version="${ZUTIL_TAG#v}"
-        version="${version//-/}"
-        whl_name="nanvix_zutil-${version}-py3-none-any.whl"
-        whl_url="${ZUTIL_RELEASE_BASE}/${ZUTIL_TAG}/${whl_name}"
-        echo "bootstrap: installing nanvix-zutil (${ZUTIL_TAG}) …" >&2
-        tmp_req=$(mktemp)
-        trap 'rm -f "${tmp_req}"' EXIT
-        echo "nanvix_zutil @ ${whl_url} --hash=${ZUTIL_HASH}" > "${tmp_req}"
-        "${VENV_PYTHON}" -m pip install -q --require-hashes -r "${tmp_req}"
-        rm -f "${tmp_req}"
-        trap - EXIT
-    fi
-fi
-
-exec "${VENV_PYTHON}" "${Z_SCRIPT}" "$@"
+case "$(uname -s)" in
+    CYGWIN*|MINGW*|MSYS*)
+        exec powershell.exe -NoProfile -ExecutionPolicy Bypass \
+            -File "$SCRIPT_DIR/z.ps1" "$@"
+        ;;
+    *)
+        exec "$SCRIPT_DIR/z.sh" "$@"
+        ;;
+esac

--- a/z.sh
+++ b/z.sh
@@ -1,15 +1,10 @@
+#!/usr/bin/env bash
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
 # Thin wrapper that delegates to the nanvix-zutil CLI.
 # Requires nanvix-zutil to be installed (pip install nanvix-zutil).
 
-param(
-    [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$Args
-)
+set -euo pipefail
 
-$ErrorActionPreference = 'Stop'
-
-& nanvix-zutil @Args
-exit $LASTEXITCODE
+exec nanvix-zutil "$@"


### PR DESCRIPTION
## Summary

Migrate the zlib Nanvix port from the legacy `./z` / `z.ps1` bootstrap wrappers to the `nanvix-zutil` standalone CLI, as shipped in [nanvix/zutils#33](https://github.com/nanvix/zutils/pull/33).

## What changed

### Deleted: bootstrap wrappers
- `z` (bash, 119 lines) and `z.ps1` (PowerShell, 123 lines) — replaced by `nanvix-zutil` installed from the GitHub Releases wheel.

### New: package manifest
- `.nanvix/nanvix.toml` — declares `name = "zlib"`, `version = "1.3.1"`, `nanvix-version = "latest"`. No dependencies (standalone library).

### Rewritten: CI workflow (`.github/workflows/nanvix-ci.yml`)
- New `get-nanvix-info` job using `nanvix-zutil resolve` (replaces 35-line inline shell).
- Build job installs wheel from GitHub Releases, then `nanvix-zutil setup/build/test/release`.
- Semver-based release tags (`{version}-nanvix-{nanvix_version}`) instead of commit-SHA-based.
- Lockfile generation step (`nanvix-zutil lock --shallow`) in the release job.
- Bumped GitHub Actions: checkout/upload/download v4 → v5, github-script v7 → v8.
- Added assignee reconciliation to failure reporting.

### Updated: z.py and documentation
- `.nanvix/z.py` — replaced `./z` references with `nanvix-zutil` in docstrings and error messages.
- `NANVIX.md` — updated Quick Start, Building, Testing, and CI/CD sections for the new CLI.

## Invocation patterns

| Context | Before | After |
|---|---|---|
| Local dev | `./z build` | `nanvix-zutil build` |
| CI (resolve) | Inline shell in release job | `nanvix-zutil resolve >> "$GITHUB_OUTPUT"` |
| CI (build) | `apt-get install python3-pip && ./z setup` | `pip install` wheel + `nanvix-zutil setup` |

## Reference

- nanvix/zutils#33 — _"Ship nanvix-zutil as a standalone CLI"_
