### PR TITLE
[ci] Update zutil-version to v0.4.2

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
-      zutil-version: "v0.4.0"
+      zutil-version: "v0.4.2"
       caller-event-name: ${{ github.event_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automated bump of `zutil-version` to [`v0.4.2`](https://github.com/nanvix/zutils/releases/tag/v0.4.2).

Generated by the [Update Zutils Version](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.