### PR TITLE
feat: add nanvix-zutil bootstrap fallback and normalize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ example.elf
 .nanvix/sysroot/
 .nanvix/buildroot/
 .nanvix/env.json
+.nanvix/nanvix.lock
 dist/

--- a/z.ps1
+++ b/z.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Thin wrapper that delegates to the nanvix-zutil CLI.
-# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+# Self-bootstraps nanvix-zutil into .nanvix\venv\ if it is not already installed.
 
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -11,5 +11,46 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-& nanvix-zutil @Args
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+    exit $LASTEXITCODE
+}
+
+# z.ps1 lives at the repository root, so use its directory directly
+# instead of relying on git to discover the top-level checkout directory.
+$repoRoot = $PSScriptRoot
+$venvDir = Join-Path $repoRoot ".nanvix\venv"
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+$venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+
+if (-not (Test-Path $venvZutil)) {
+    # Pin nanvix-zutil version for reproducible bootstrapping.
+    # Override with NANVIX_ZUTIL_VERSION env var if needed.
+    $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) { $env:NANVIX_ZUTIL_VERSION } else { "0.4.2" }
+    Write-Host "nanvix-zutil not found — bootstrapping nanvix-zutil==${zutilVersion}..." -ForegroundColor Yellow
+
+    $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
+
+    # Discover a Python 3 interpreter.
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        & py -3 -m venv $venvDir
+    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+        & python -m venv $venvDir
+    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+        & python3 -m venv $venvDir
+    } else {
+        throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
+    }
+    & $venvPython -m pip install --quiet $wheelUrl
+}
+
+# Prefer the venv copy; fall back to global.
+if (Test-Path $venvZutil) {
+    & $venvZutil @Args
+} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
+    & nanvix-zutil @Args
+} else {
+    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+}
 exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -3,8 +3,48 @@
 # Licensed under the MIT License.
 
 # Thin wrapper that delegates to the nanvix-zutil CLI.
-# Requires nanvix-zutil to be installed (pip install nanvix-zutil).
+# Self-bootstraps nanvix-zutil into .nanvix/venv/ if it is not already installed.
 
 set -euo pipefail
 
-exec nanvix-zutil "$@"
+# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
+if command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+# z.sh lives at the repository root, so use its directory directly
+# instead of relying on git to discover the top-level checkout directory.
+REPO_ROOT="$SCRIPT_DIR"
+
+VENV="$REPO_ROOT/.nanvix/venv"
+
+if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null; then
+	# Pin nanvix-zutil version for reproducible bootstrapping.
+	# Override with NANVIX_ZUTIL_VERSION env var if needed.
+	ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.4.2}"
+	echo "nanvix-zutil not found — bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+
+	if ! command -v python3 &>/dev/null; then
+		echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
+		exit 1
+	fi
+
+	WHEEL_URL="https://github.com/nanvix/zutils/releases/download/v${ZUTIL_VERSION}/nanvix_zutil-${ZUTIL_VERSION}-py3-none-any.whl"
+	if [ -d "$VENV" ]; then
+		python3 -m venv --clear "$VENV"
+	else
+		python3 -m venv "$VENV"
+	fi
+	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
+fi
+
+# Prefer the venv copy if it exists; otherwise use the global install.
+if [ -x "$VENV/bin/nanvix-zutil" ]; then
+	exec "$VENV/bin/nanvix-zutil" "$@"
+elif command -v nanvix-zutil &>/dev/null; then
+	exec nanvix-zutil "$@"
+else
+	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

- Add self-bootstrapping fallback to `z.sh` and `z.ps1`: on first run, if `nanvix-zutil` is not installed, the scripts fetch the latest wheel from the GitHub API (using `curl` + `python3` — no `gh` or `jq` required), install it into `.nanvix/venv/`, and proceed transparently
- Normalize `.gitignore` Nanvix block: add missing `.nanvix/nanvix.lock` entry to match the canonical template in [nanvix/zutils#38](https://github.com/nanvix/zutils/pull/38)