### PR TITLE
[ci] Sync zutils v0.5.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
-      zutil-version: "v0.5.0"
+      zutil-version: "v0.5.1"
       caller-event-name: ${{ github.event_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/z.ps1
+++ b/z.ps1
@@ -6,15 +6,16 @@
 
 param(
     [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]]$Args
+    [string[]]$ZArgs
 )
 
 $ErrorActionPreference = 'Stop'
 
-# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
-if (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
-    & nanvix-zutil @Args
-    exit $LASTEXITCODE
+$zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
+    $env:NANVIX_ZUTIL_VERSION
+}
+else {
+    "0.5.1"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly
@@ -23,11 +24,16 @@ $repoRoot = $PSScriptRoot
 $venvDir = Join-Path $repoRoot ".nanvix\venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"
 $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+$zutilGlobalVersion = try {
+    & nanvix-zutil --version 2>$null
+}
+catch {
+    $null
+}
 
-if (-not (Test-Path $venvZutil)) {
+function Bootstrap {
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) { $env:NANVIX_ZUTIL_VERSION } else { "0.4.2" }
     Write-Host "nanvix-zutil not found — bootstrapping nanvix-zutil==${zutilVersion}..." -ForegroundColor Yellow
 
     $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
@@ -35,22 +41,39 @@ if (-not (Test-Path $venvZutil)) {
     # Discover a Python 3 interpreter.
     if (Get-Command py -ErrorAction SilentlyContinue) {
         & py -3 -m venv $venvDir
-    } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+    }
+    elseif (Get-Command python -ErrorAction SilentlyContinue) {
         & python -m venv $venvDir
-    } elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+    }
+    elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
         & python3 -m venv $venvDir
-    } else {
+    }
+    else {
         throw "Python 3 not found. Install Python 3 and ensure py, python, or python3 is on PATH."
     }
     & $venvPython -m pip install --quiet $wheelUrl
 }
 
-# Prefer the venv copy; fall back to global.
-if (Test-Path $venvZutil) {
-    & $venvZutil @Args
-} elseif (Get-Command nanvix-zutil -ErrorAction SilentlyContinue) {
-    & nanvix-zutil @Args
-} else {
-    throw "nanvix-zutil not found in venv ($venvDir) or on PATH."
+# Prefer the venv copy if it exists; otherwise use the global install.
+$bin = $null
+if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
+    Bootstrap
+    $bin = $venvZutil
 }
+elseif (Test-Path $venvZutil) {
+    $bin = $venvZutil
+}
+elseif ((Test-Path $venvDir) -and (-not $zutilGlobalVersion)) {
+    Write-Warning "Incomplete venv detected (binary missing). Re-running bootstrap..."
+    Bootstrap
+    $bin = $venvZutil
+}
+else {
+    $bin = "nanvix-zutil"
+    if ($zutilGlobalVersion -ne "nanvix-zutil ${zutilVersion}") {
+        Write-Warning "nanvix-zutil global install does not match expected version. Expected ${zutilVersion}, found ${zutilGlobalVersion}."
+    }
+}
+
+& $bin @ZArgs
 exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -7,22 +7,15 @@
 
 set -euo pipefail
 
-# If nanvix-zutil is already on PATH (e.g. CI), use it directly.
-if command -v nanvix-zutil &>/dev/null; then
-	exec nanvix-zutil "$@"
-fi
-
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
-# z.sh lives at the repository root, so use its directory directly
-# instead of relying on git to discover the top-level checkout directory.
-REPO_ROOT="$SCRIPT_DIR"
-
+ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.5.1}"
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
+VENV_BIN="$VENV/bin/nanvix-zutil"
+ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true )"
 
-if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null; then
+function bootstrap() {
 	# Pin nanvix-zutil version for reproducible bootstrapping.
 	# Override with NANVIX_ZUTIL_VERSION env var if needed.
-	ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.4.2}"
 	echo "nanvix-zutil not found — bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
 
 	if ! command -v python3 &>/dev/null; then
@@ -37,14 +30,24 @@ if ! "$VENV/bin/nanvix-zutil" --version &>/dev/null; then
 		python3 -m venv "$VENV"
 	fi
 	"$VENV/bin/pip" install --quiet "$WHEEL_URL"
-fi
+}
 
 # Prefer the venv copy if it exists; otherwise use the global install.
-if [ -x "$VENV/bin/nanvix-zutil" ]; then
-	exec "$VENV/bin/nanvix-zutil" "$@"
-elif command -v nanvix-zutil &>/dev/null; then
-	exec nanvix-zutil "$@"
+BIN=""
+if [ ! -d "$VENV" ] && [ -z "$ZUTIL_GLOBAL_VERSION" ]; then
+    bootstrap
+    BIN="$VENV_BIN"
+elif [ -x "$VENV_BIN" ]; then
+    BIN="$VENV_BIN"
+elif [ -d "$VENV" ] && ! command -v nanvix-zutil &>/dev/null; then
+    echo "Warning: incomplete venv detected (binary missing). Re-running bootstrap..." >&2
+    bootstrap
+    BIN="$VENV_BIN"
 else
-	echo "nanvix-zutil not found in venv ($VENV) or on PATH." >&2
-	exit 1
+    BIN="nanvix-zutil"
+    if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
+        echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+    fi
 fi
+
+exec "$BIN" "$@"


### PR DESCRIPTION
Automated sync with [`v0.5.1`](https://github.com/nanvix/zutils/releases/tag/v0.5.1):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.