### PR TITLE
[ci] Sync zutils v0.7.2

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
     with:
-      zutil-version: "v0.7.1"
+      zutil-version: "v0.7.2"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: ${{ github.event_name }}
     secrets:

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.1"
+    "0.7.2"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly
@@ -24,6 +24,12 @@ $repoRoot = $PSScriptRoot
 $venvDir = Join-Path $repoRoot ".nanvix\venv"
 $venvPython = Join-Path $venvDir "Scripts\python.exe"
 $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
+
+# Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
+# which are unavailable on Windows.  Stub them before importing the package.
+# FIXME: https://github.com/nanvix/zutils/issues/56
+$ShimCode = 'import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())'
+
 $zutilGlobalVersion = try {
     & nanvix-zutil --version 2>$null
 }
@@ -76,11 +82,13 @@ if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     $bin = $venvZutil
 }
 elseif (Test-Path $venvZutil) {
+    # Use the shim to check version -- running the exe directly fails on
+    # Windows because os.getuid/os.getgid are unavailable (see FIXME above).
     $venvVersion = try {
-        & $venvZutil --version 2>$null 
+        & $venvPython -c $ShimCode --version 2>$null
     }
     catch {
-        $null 
+        $null
     }
     if ($venvVersion -ne "nanvix-zutil ${zutilVersion}") {
         Write-Warning "Venv nanvix-zutil version mismatch. Expected ${zutilVersion}, found ${venvVersion}. Re-bootstrapping..."
@@ -106,5 +114,10 @@ else {
     }
 }
 
-& $bin @ZArgs
+if ($bin -eq $venvZutil) {
+    & $venvPython -c $ShimCode @ZArgs
+}
+else {
+    & $bin @ZArgs
+}
 exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -7,11 +7,23 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.1"
+PINNED_VERSION="0.7.2"
 ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
-VENV_BIN="$VENV/bin/nanvix-zutil"
+
+# Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
+# Must be called after venv creation to pick up the correct paths.
+function _resolve_venv_paths() {
+    if [ -d "$VENV/Scripts" ]; then
+        VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"
+        VENV_PYTHON="$VENV/Scripts/python.exe"
+    else
+        VENV_BIN="$VENV/bin/nanvix-zutil"
+        VENV_PYTHON="$VENV/bin/python"
+    fi
+}
+_resolve_venv_paths
 ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 
 function bootstrap() {
@@ -30,7 +42,9 @@ function bootstrap() {
     else
         python3 -m venv "$VENV"
     fi
-    "$VENV/bin/pip" install --quiet "$WHEEL_URL"
+    # Re-resolve paths now that the venv exists (Scripts/ vs bin/).
+    _resolve_venv_paths
+    "$VENV_PYTHON" -m pip install --quiet "$WHEEL_URL"
 }
 
 # Prefer the venv copy if it exists; otherwise use the global install.


### PR DESCRIPTION
Automated sync with [`v0.7.2`](https://github.com/nanvix/zutils/releases/tag/v0.7.2):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.