### PR TITLE
Refactor build system: move Nanvix files to .nanvix/ and fix standalone tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ example.elf
 .nanvix/buildroot/
 .nanvix/env.json
 .nanvix/nanvix.lock
-dist/
+.nanvix/__pycache__

--- a/.nanvix/Makefile.nanvix
+++ b/.nanvix/Makefile.nanvix
@@ -96,7 +96,7 @@ ifdef CONFIG_NANVIX
   endif
 else
   ifneq ($(MAKECMDGOALS),clean)
-    $(error CONFIG_NANVIX must be set to 'y'. Usage: make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/sysroot)
+    $(error CONFIG_NANVIX must be set to 'y'. Usage: make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/sysroot)
   endif
   EXE = .elf
 endif
@@ -188,16 +188,16 @@ ifeq ($(PROCESS_MODE),standalone)
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "  Running example$(EXE) via nanvixd.elf standalone (Docker)..."
 	$(DOCKER_RUN_FUNCTIONAL) sh -c '\
-	  mkdir -p /tmp/nanvix-ramfs && \
+	  mkdir -p /tmp/nanvix-ramfs/tmp && \
 	  cp $(DOCKER_WORKSPACE_PATH)/example$(EXE) /tmp/nanvix-ramfs/ && \
 	  ./bin/mkramfs.elf -o /tmp/rootfs.img /tmp/nanvix-ramfs/ && \
 	  timeout --foreground 120 ./bin/nanvixd.elf \
 	    -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	    -- ./example$(EXE) /tmp/zlib_test'
+	    -- $(DOCKER_WORKSPACE_PATH)/example$(EXE) /tmp/zlib_test'
 	@echo "  PASS: example test standalone (exit code 0)"
 else
 	@echo "  Running example$(EXE) via nanvixd.elf standalone..."
-	@rm -rf /tmp/nanvix-ramfs && mkdir -p /tmp/nanvix-ramfs
+	@rm -rf /tmp/nanvix-ramfs && mkdir -p /tmp/nanvix-ramfs/tmp
 	@cp $(abspath example$(EXE)) /tmp/nanvix-ramfs/
 	"$(SYSROOT_PATH)/bin/mkramfs.elf" -o /tmp/rootfs.img /tmp/nanvix-ramfs/
 	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf \

--- a/.nanvix/NANVIX.md
+++ b/.nanvix/NANVIX.md
@@ -69,10 +69,10 @@ tar -xjf nanvix-artifacts/*microvm*single*.tar.bz2 -C nanvix-artifacts
 export NANVIX_HOME=$(find nanvix-artifacts -maxdepth 2 -type d -name "bin" -exec dirname {} \; | head -1)
 
 # 3. Build (Docker is used automatically if native toolchain is not found)
-make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME"
+make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME"
 
 # 4. Run tests
-make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" test
+make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" test
 ```
 
 Continue reading for detailed instructions.
@@ -135,7 +135,7 @@ The Makefile supports automatic Docker fallback when the native toolchain is not
 docker pull nanvix/toolchain:latest-minimal
 
 # Build (Docker is used automatically if native toolchain is not found)
-make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
+make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
 ```
 
 > **Note:** The sysroot (`NANVIX_HOME`) must contain `lib/libposix.a` and `lib/user.ld` from a Nanvix build.
@@ -151,7 +151,7 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 ```bash
 export NANVIX_TOOLCHAIN=/path/to/toolchain  # Contains: bin/i686-nanvix-gcc
 export NANVIX_HOME=/path/to/nanvix          # Contains: lib/user.ld, lib/libposix.a
-make -f Makefile.nanvix CONFIG_NANVIX=y all
+make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y all
 ```
 
 ### Build Outputs
@@ -183,7 +183,7 @@ After a successful build, you will have:
 Alternatively, invoke Make directly:
 
 ```bash
-make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix test
+make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix test
 ```
 
 ### Running Individual Tests
@@ -211,7 +211,7 @@ The following changes were made to support Nanvix.
 
 | Change | Description |
 |--------|-------------|
-| New Makefile | Added `Makefile.nanvix` for Nanvix cross-compilation |
+| New Makefile | Added `.nanvix/Makefile.nanvix` for Nanvix cross-compilation |
 | Cross-compilation | Uses `CONFIG_NANVIX=y` option to enable Nanvix build |
 | Docker support | Automatic Docker fallback when native toolchain not available |
 | Linker flags | Added Nanvix-specific flags (`-T user.ld -static`) |
@@ -222,8 +222,8 @@ The following changes were made to support Nanvix.
 
 | File | Purpose |
 |------|---------|
-| `Makefile.nanvix` | Standalone Makefile for Nanvix cross-compilation |
-| `NANVIX.md` | This documentation file |
+| `.nanvix/Makefile.nanvix` | Standalone Makefile for Nanvix cross-compilation |
+| `.nanvix/NANVIX.md` | This documentation file |
 | `z` | Unified entry point (delegates to `z.sh` or `z.ps1`) |
 | `z.sh` | Bash wrapper that delegates to `nanvix-zutil` CLI |
 | `z.ps1` | PowerShell wrapper that delegates to `nanvix-zutil` CLI |

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -37,7 +37,7 @@ class ZlibBuild(ZScript):
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
 
         args = [
-            "make", "-f", "Makefile.nanvix",
+            "make", "-f", ".nanvix/Makefile.nanvix",
             f"{_MAKE_VAR_CONFIG}=y",
             f"{_MAKE_VAR_HOME}={sysroot}",
             f"{_MAKE_VAR_TOOLCHAIN}={toolchain}",
@@ -78,7 +78,7 @@ class ZlibBuild(ZScript):
     def clean(self) -> None:
         """Remove build artifacts."""
         self.run(
-            "make", "-f", "Makefile.nanvix", "clean",
+            "make", "-f", ".nanvix/Makefile.nanvix", "clean",
             cwd=self.repo_root,
         )
 


### PR DESCRIPTION
## Summary

Move Nanvix-specific build files (`Makefile.nanvix`, `NANVIX.md`) into the `.nanvix/` directory and fix two bugs in the standalone functional tests.

## Changes

- **Relocate build files**: Move `Makefile.nanvix` and `NANVIX.md` to `.nanvix/` to keep Nanvix-specific files organized
- **Update all references**: Fix paths in `z.py`, `NANVIX.md`, and the Makefile error message
- **Fix standalone Docker test path**: Use `$(DOCKER_WORKSPACE_PATH)/example.elf` instead of `./example.elf` so `nanvixd.elf` can find the binary (working directory is `/mnt/sysroot`, not `/mnt/workspace`)
- **Fix ramfs /tmp directory**: Create `/tmp` inside the ramfs image so `gzopen()` can write test files during functional tests
- **Update .gitignore**: Exclude `.nanvix/__pycache__`

## Testing

All test levels pass (`./z test`): smoke, integration, and functional (standalone Docker with KVM).