### PR TITLE
fix(Makefile.nanvix): use absolute path for nanvixd binary argument

### DIFF
--- a/.nanvix/Makefile.nanvix
+++ b/.nanvix/Makefile.nanvix
@@ -202,7 +202,7 @@ else
 	"$(SYSROOT_PATH)/bin/mkramfs.elf" -o /tmp/rootfs.img /tmp/nanvix-ramfs/
 	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd.elf \
 	  -bin-dir ./bin -ramfs /tmp/rootfs.img \
-	  -- ./example$(EXE) /tmp/zlib_test
+	  -- $(abspath example$(EXE)) /tmp/zlib_test
 	@rm -rf /tmp/nanvix-ramfs /tmp/rootfs.img
 	@echo "  PASS: example test standalone (exit code 0)"
 endif


### PR DESCRIPTION
nanvixd uses mmap() to load the user binary from the host filesystem path given after `--`. The standalone non-Docker test recipe does `cd $(SYSROOT_PATH)` before invoking nanvixd, so `./binary.elf` resolves relative to the sysroot — where the binary does not exist.

Replace relative paths with `$(abspath ...)` so nanvixd can find the binary regardless of the working directory. The non-standalone recipes already used `$(abspath ...)` correctly.

Part of nanvix/zutils#130.