### PR TITLE
[ci] E: Update nanvix workflow refs to v1.11.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.1
     with:
       zutil-version: "v0.7.25"
       memory-sizes: '["128mb","256mb"]'
@@ -41,7 +41,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.1
     with:
       zutil-version: "v0.7.25"
       memory-sizes: '["128mb","256mb"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.11.1`](https://github.com/nanvix/workflows/releases/tag/v1.11.1).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.