### PR TITLE
ci: adopt docker-build / native-test workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,11 +25,12 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.7.6
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
-      zutil-version: "v0.7.19"
+      zutil-version: "v0.7.26"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: ${{ github.event_name }}
+      windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -41,11 +42,12 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.7.6
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
-      zutil-version: "v0.7.19"
+      zutil-version: "v0.7.26"
       memory-sizes: '["128mb","256mb"]'
       caller-event-name: 'schedule'
+      windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary
Adopt the new docker-build / native-test CI workflow (v1.12.0).

### Changes
- **Workflow**: Update to `nanvix/workflows@v1.12.0`
- **zutil**: Update to `v0.7.26` (Docker flags moved to setup subcommand)
- **Windows test**: Enable artifact-based Windows testing on `windows-latest`

### How it works
- **Linux**: Build with Docker (`nanvix-zutil setup --with-docker` + `nanvix-zutil build`), test natively (KVM)
- **Windows**: Download ELF binaries from Linux build, test natively (`nanvixd.exe`)
- All on GitHub-hosted runners (no self-hosted required)