### PR TITLE
ci: remove hyperlight from CI matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,12 +28,9 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.48"
-      platforms: '["hyperlight","microvm"]'
+      platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: >-
-        [{"platform":"hyperlight","process-mode":"multi-process"},
-        {"platform":"hyperlight","process-mode":"single-process"}]
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
@@ -52,12 +49,9 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.48"
-      platforms: '["hyperlight","microvm"]'
+      platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
       memory-sizes: '["128mb","256mb"]'
-      matrix-exclude: >-
-        [{"platform":"hyperlight","process-mode":"multi-process"},
-        {"platform":"hyperlight","process-mode":"single-process"}]
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'


### PR DESCRIPTION
Remove hyperlight platform from CI matrix configuration. This removes hyperlight from `platforms`, cleans up `matrix-exclude` and `windows-matrix-exclude` entries that were only needed for hyperlight.