### PR TITLE
[ci] E: Update nanvix workflow refs to v1.15.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'
@@ -46,7 +46,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
     with:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'

--- a/.nanvix/Makefile.nanvix
+++ b/.nanvix/Makefile.nanvix
@@ -17,7 +17,7 @@
 # Toolchain Detection
 # ===========================================================================
 
-NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+NANVIX_DOCKER_IMAGE ?= ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 ifdef CONFIG_NANVIX
   NANVIX_TOOLCHAIN ?= /opt/nanvix
@@ -28,12 +28,15 @@ ifdef CONFIG_NANVIX
       DOCKER_AVAILABLE := $(shell command -v docker 2>/dev/null)
       ifdef DOCKER_AVAILABLE
         DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
-        ifdef DOCKER_IMAGE_EXISTS
-          CONFIG_NANVIX_DOCKER := y
-          $(info [nanvix] Using Docker (native toolchain not found at $(NANVIX_TOOLCHAIN)))
-        else
-          $(error Docker image $(NANVIX_DOCKER_IMAGE) not found. Run: docker pull $(NANVIX_DOCKER_IMAGE))
+        ifndef DOCKER_IMAGE_EXISTS
+          $(info [nanvix] Pulling Docker image $(NANVIX_DOCKER_IMAGE)...)
+          DOCKER_PULL_RESULT := $(shell docker pull $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
+          ifndef DOCKER_PULL_RESULT
+            $(error Failed to pull Docker image $(NANVIX_DOCKER_IMAGE))
+          endif
         endif
+        CONFIG_NANVIX_DOCKER := y
+        $(info [nanvix] Using Docker (native toolchain not found at $(NANVIX_TOOLCHAIN)))
       else
         $(error Nanvix toolchain not found at $(NANVIX_TOOLCHAIN) and Docker not available)
       endif
@@ -45,7 +48,11 @@ ifdef CONFIG_NANVIX
     endif
     DOCKER_IMAGE_EXISTS := $(shell docker image inspect $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
     ifndef DOCKER_IMAGE_EXISTS
-      $(error Docker image $(NANVIX_DOCKER_IMAGE) not found. Run: docker pull $(NANVIX_DOCKER_IMAGE))
+      $(info [nanvix] Pulling Docker image $(NANVIX_DOCKER_IMAGE)...)
+      DOCKER_PULL_RESULT := $(shell docker pull $(NANVIX_DOCKER_IMAGE) >/dev/null 2>&1 && echo yes)
+      ifndef DOCKER_PULL_RESULT
+        $(error Failed to pull Docker image $(NANVIX_DOCKER_IMAGE))
+      endif
     endif
     $(info [nanvix] Using Docker (explicitly requested))
   endif
@@ -235,10 +242,10 @@ package: all
 	cp -f $(STATICLIB) dist/$(ARTIFACT_NAME)/sysroot/lib/
 	cp -f zlib.h zconf.h dist/$(ARTIFACT_NAME)/sysroot/include/
 	-cp -f $(TEST_PROGS) dist/$(ARTIFACT_NAME)/sysroot/bin/ 2>/dev/null || true
-	tar -cjf dist/$(ARTIFACT_NAME).tar.bz2 -C dist/$(ARTIFACT_NAME) sysroot
-	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
+	tar -czf dist/$(ARTIFACT_NAME).tar.gz -C dist/$(ARTIFACT_NAME) sysroot
+	@echo "  Package: dist/$(ARTIFACT_NAME).tar.gz"
 	@echo "  Contents:"
-	@tar tjf dist/$(ARTIFACT_NAME).tar.bz2 | head -20
+	@tar tzf dist/$(ARTIFACT_NAME).tar.gz | head -20
 
 # ===========================================================================
 # Verify Package
@@ -247,13 +254,13 @@ package: all
 verify-package:
 	@echo "=== Verifying zlib package ==="
 	$(eval ARTIFACT_NAME := zlib-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
-	@TARBALL="dist/$(ARTIFACT_NAME).tar.bz2"; \
+	@TARBALL="dist/$(ARTIFACT_NAME).tar.gz"; \
 	if [ ! -f "$$TARBALL" ]; then \
 	  echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \
 	fi; \
 	echo "Package contents:"; \
-	tar tjf "$$TARBALL"; \
-	if ! tar tjf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
+	tar tzf "$$TARBALL"; \
+	if ! tar tzf "$$TARBALL" | grep -q 'sysroot/lib/'; then \
 	  echo "FAIL: Package missing sysroot/lib/ entries"; exit 1; \
 	fi; \
 	echo "  PASS: zlib package verification"

--- a/.nanvix/README.md
+++ b/.nanvix/README.md
@@ -56,7 +56,7 @@ No other `.c` or `.h` files were modified. The compression algorithms, public AP
 | Compiler | `i686-nanvix-gcc` |
 | Archiver | `i686-nanvix-ar` |
 | Ranlib | `i686-nanvix-ranlib` |
-| Docker image | `nanvix/toolchain:latest-minimal` |
+| Docker image | `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` |
 | CFLAGS | `-O2 -Wall -D_GNU_SOURCE -msse2 -mfpmath=sse` |
 | LDFLAGS | `-T user.ld -static -Wl,-z,noexecstack` |
 
@@ -100,7 +100,7 @@ Override the pinned nanvix-zutil version with `NANVIX_ZUTIL_VERSION=<version>`.
 
 ```bash
 # Pull the Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
 
 # Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh \
@@ -131,7 +131,7 @@ make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y
 | `NANVIX_HOME` | `$HOME/nanvix` | Path to Nanvix sysroot (must contain `lib/user.ld`) |
 | `NANVIX_TOOLCHAIN` | `/opt/nanvix` | Path to cross-compiler (must contain `bin/i686-nanvix-gcc`) |
 | `CONFIG_NANVIX_DOCKER` | *(auto)* | Set to `y` to force Docker even when native toolchain exists |
-| `NANVIX_DOCKER_IMAGE` | `nanvix/toolchain:latest-minimal` | Docker image for cross-compilation |
+| `NANVIX_DOCKER_IMAGE` | `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` | Docker image for cross-compilation |
 | `PLATFORM` | `unknown` | Target platform name (`microvm`, `hyperlight`) |
 | `PROCESS_MODE` | `unknown` | Deployment mode (`multi-process`, `single-process`, `standalone`) |
 | `MEMORY_SIZE` | `unknown` | Memory configuration (`128mb`, `256mb`) |

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -19,6 +19,9 @@ from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, 
 
 IS_WINDOWS = sys.platform == "win32"
 
+#: Docker image for cross-compiling Nanvix targets.
+NANVIX_DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
+
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
 _MAKE_VAR_HOME = "NANVIX_HOME"
@@ -30,6 +33,10 @@ _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
 class ZlibBuild(ZScript):
     """Build script for nanvix/zlib."""
+
+    def docker_image(self) -> str:
+        """Return the default Docker image for cross-compilation."""
+        return NANVIX_DOCKER_IMAGE
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list."""


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.15.0`](https://github.com/nanvix/workflows/releases/tag/v1.15.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.