### PR TITLE
[ci] E: Pin nanvix to v0.15.13

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zlib"
 version = "1.3.1"
-nanvix-version = "0.15.5"
+nanvix-version = "0.15.13"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.15.13`](https://github.com/nanvix/nanvix/releases/tag/v0.15.13).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.