### PR TITLE
Remove nanvix.lock from .gitignore

### DIFF
--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -6,5 +6,4 @@ buildroot/
 .yamllint.yml
 black.toml
 env.json
-nanvix.lock
 pyrightconfig.json


### PR DESCRIPTION
Removes the `nanvix.lock` entry from `.nanvix/.gitignore` so the lock file is tracked in the repository.