### PR TITLE
Copy build artifacts back

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,6 +11,7 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
+import dataclasses
 import sys
 from pathlib import Path
 
@@ -18,12 +19,21 @@ from nanvix_zutil import (
     CFG_SYSROOT,
     EXIT_MISSING_DEP,
     TOOLCHAIN_CONTAINER_PATH,
+    DockerConfig,
     ZScript,
     log,
     make_initrd,
     run,
 )
 from nanvix_zutil.helpers import InitRdArgs
+
+#: Build artifacts produced inside the container that must be copied back
+#: to the host workspace so that `./z test` and `./z release` can find them.
+_BUILD_OUTPUT_FILES = [
+    "libz.a",
+    "example.elf",
+    "minigzip.elf",
+]
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -44,6 +54,16 @@ class ZlibBuild(ZScript):
     def docker_image(self) -> str:
         """Return the default Docker image for cross-compilation."""
         return NANVIX_DOCKER_IMAGE
+
+    def docker_config(self, image: str) -> DockerConfig:
+        """Extend the default Docker config with build artifact copy-back.
+
+        On Windows the build runs in a container-local directory (tar-copy
+        mode), so output files must be explicitly copied back to the
+        workspace mount; otherwise `./z test` cannot find example.elf.
+        """
+        cfg = super().docker_config(image)
+        return dataclasses.replace(cfg, output_files=list(_BUILD_OUTPUT_FILES))
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the common make argument list.


### PR DESCRIPTION
On Windows the Docker wrapper runs the build in tar-copy mode: sources are copied from the workspace mount into a container-local directory (/tmp/build) and the make recipes write their outputs there. The wrapper only copies a file back to the workspace mount if it is listed in DockerConfig.output_files, and ZlibBuild left that list empty.

As a result, `./z build` succeeded inside the container but produced no host-visible artifacts, and the subsequent `./z test` failed with:

    error: No allowlisted test binaries found. Expected: example.elf.
    hint: Build the test binaries first (for example, run `./z build`)
          and then rerun `./z test`.

Override ZlibBuild.docker_config to extend the default config with output_files = ["libz.a", "example.elf", "minigzip.elf"] via dataclasses.replace, so the wrapper copies these artifacts back to the workspace after the build. This restores the expected `./z build` → `./z test` flow on Windows; Linux/macOS builds are unaffected because they build directly in the mounted workspace.