### PR TITLE
[nanvix] Drop smoke and integration test targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ contrib/nuget/obj
 
 minigzip.elf
 example.elf
+
+# Nanvix
+nanvixd_*.log

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ example.elf
 
 # Nanvix
 nanvixd_*.log
+pyrightconfig.json

--- a/.nanvix/Makefile.nanvix
+++ b/.nanvix/Makefile.nanvix
@@ -6,9 +6,7 @@
 #
 # Targets:
 #   all: Build static library and test programs
-#   test: Run all tests (smoke, integration, functional)
-#   test-smoke: Verify build artifacts (no runtime needed)
-#   test-integration: Verify test program build artifacts
+#   test: Run functional tests
 #   test-functional: Run example.elf on nanvixd$(EXE)
 #   package: Create a release tarball with build artifacts and headers
 #   verify-package: Verify the contents of the release tarball
@@ -120,27 +118,8 @@ zutil.o: zutil.c zutil.h zlib.h zconf.h
 # Test Targets
 # ===========================================================================
 
-# --- Smoke tests: verify build artifacts (no runtime needed) ---
-test-smoke:
-	@echo "=== zlib smoke tests ==="
-	@test -f $(STATICLIB) || { echo "  FAIL: $(STATICLIB) not found"; exit 1; }
-	@size=$$(wc -c < $(STATICLIB)); \
-	  if [ "$$size" -lt 1000 ]; then echo "  FAIL: $(STATICLIB) too small"; exit 1; fi
-	@test -f zlib.h || { echo "  FAIL: zlib.h not found"; exit 1; }
-	@test -f zconf.h || { echo "  FAIL: zconf.h not found"; exit 1; }
-	@echo "  PASS: zlib smoke tests"
-
-# --- Integration tests: verify test program build artifacts ---
-test-integration:
-	@echo "=== zlib integration tests ==="
-	@test -f example$(EXE) || { echo "  FAIL: example$(EXE) not built"; exit 1; }
-	@test -f minigzip$(EXE) || { echo "  FAIL: minigzip$(EXE) not built"; exit 1; }
-	@echo "  OK: example$(EXE) ($$(wc -c < example$(EXE)) bytes)"
-	@echo "  OK: minigzip$(EXE) ($$(wc -c < minigzip$(EXE)) bytes)"
-	@echo "  PASS: zlib integration tests"
-
 # --- Functional tests: run example.elf on nanvixd$(EXE) ---
-test-functional: test-integration
+test-functional:
 	@echo "=== zlib functional tests ==="
 ifeq ($(PROCESS_MODE),standalone)
 	@echo "  Standalone functional tests are handled by ./z test"
@@ -152,7 +131,7 @@ endif
 	@echo "  PASS: zlib functional tests"
 
 # --- Run all test levels ---
-test: test-smoke test-integration test-functional
+test: test-functional
 	@echo "=== All zlib tests PASSED ==="
 
 # ===========================================================================
@@ -206,4 +185,4 @@ clean:
 	rm -f *.a *$(EXE)
 	rm -rf dist/
 
-.PHONY: all clean test test-smoke test-integration test-functional package verify-package
+.PHONY: all clean test test-functional package verify-package

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -117,12 +117,6 @@ class ZlibBuild(ZScript):
             return
 
         if self.config.deployment_mode == "standalone":
-            # Smoke + integration via Makefile (host-side; recipes only
-            # touch already-built artifacts), functional via Python.
-            run(
-                *self._make_args("test-smoke", "test-integration"),
-                cwd=self.repo_root,
-            )
             self._run_functional_standalone()
         else:
             targets = self.targets if self.targets else ["test"]


### PR DESCRIPTION
## Summary

Collapses the Nanvix test pipeline to a single `test-functional` target, removing the redundant `test-smoke` and `test-integration` Make recipes and the corresponding pre-functional `make` invocation in `z.py`.

## Motivation

The `test-smoke` and `test-integration` targets duplicated checks already performed elsewhere:

- **`test-smoke`** verified that `libz.a`, `zlib.h`, and `zconf.h` exist after a build. These artifacts are produced unconditionally by `all`; their absence would already fail the build, so the post-build existence checks added no signal.
- **`test-integration`** verified that `example$(EXE)` and `minigzip$(EXE)` were built. The standalone path in `_run_functional_standalone` already calls `log.fatal` when `example.elf` is missing, and the non-standalone functional recipe surfaces a clear error from the runner if the binary is not present.

## Changes

- **`.nanvix/Makefile.nanvix`**
  - Remove `test-smoke` and `test-integration` recipes.
  - Drop `test-integration` prerequisite from `test-functional`.
  - Simplify `test` to depend only on `test-functional`.
  - Update header comment and `.PHONY` list.
- **`.nanvix/z.py`**
  - Drop the pre-functional `make test-smoke test-integration` invocation in the standalone branch of `ZlibBuild.test`.

## Behavior

No behavioral change for passing builds. Failure messages for missing artifacts now come from the build step or the functional runner rather than from dedicated smoke/integration recipes.
