### PR TITLE
build all artifacts to .nanvix/out

### DIFF
--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -7,3 +7,5 @@ buildroot/
 black.toml
 env.json
 pyrightconfig.json
+dist
+out

--- a/.nanvix/Makefile.nanvix
+++ b/.nanvix/Makefile.nanvix
@@ -27,7 +27,7 @@ _NANVIX_DOCKER_BUILD_GOALS := all example$(EXE) minigzip$(EXE)
 _NANVIX_GOALS := $(or $(MAKECMDGOALS),$(.DEFAULT_GOAL))
 
 # Ensure required variables are defined
-_REQUIRED := PLATFORM PROCESS_MODE MEMORY_SIZE NANVIX_HOME NANVIX_TOOLCHAIN
+_REQUIRED := PLATFORM PROCESS_MODE MEMORY_SIZE NANVIX_HOME NANVIX_TOOLCHAIN NANVIX_ROOT OUT_DIR DIST_DIR LIB_OUT INCLUDE_OUT TEST_OUT TEST_ARTIFACTS INCLUDE_ARTIFACTS LIB_ARTIFACTS
 ifneq ($(filter-out clean,$(_NANVIX_GOALS)),)
   $(foreach v,$(_REQUIRED),\
     $(if $($v),,$(error Required variable $v not set))\
@@ -40,9 +40,7 @@ STATICLIB = libz.a
 OBJZ = adler32.o crc32.o deflate.o infback.o inffast.o inflate.o inftrees.o trees.o zutil.o
 OBJG = compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o
 OBJS = $(OBJZ) $(OBJG)
-TEST_PROGS = example$(EXE) minigzip$(EXE)
 SYSROOT_PATH := $(abspath $(NANVIX_HOME))
-RELEASE_ARTIFACTS := $(STATICLIB) zlib.h zconf.h
 
 # ===========================================================================
 # Build Mode Variables
@@ -76,7 +74,7 @@ NANVIX_LIBS := -Wl,--start-group \
 # Build Targets
 # ===========================================================================
 
-all: $(STATICLIB) $(TEST_PROGS)
+all: $(STATICLIB) $(TEST_ARTIFACTS)
 
 $(STATICLIB): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)
@@ -92,10 +90,10 @@ test/minigzip.o: test/minigzip.c zlib.h zconf.h
 	$(CC) $(CFLAGS) -I. -c -o $@ $<
 
 example$(EXE): test/example.o $(STATICLIB)
-	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ test/example.o -L. -lz $(NANVIX_LIBS)
+	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ "test/example.o" -L. -lz $(NANVIX_LIBS)
 
 minigzip$(EXE): test/minigzip.o $(STATICLIB)
-	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ test/minigzip.o -L. -lz $(NANVIX_LIBS)
+	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ "test/minigzip.o" -L. -lz $(NANVIX_LIBS)
 
 # Source dependencies
 adler32.o: adler32.c zutil.h zlib.h zconf.h
@@ -125,7 +123,7 @@ ifeq ($(PROCESS_MODE),standalone)
 	@echo "  Standalone functional tests are handled by ./z test"
 else
 	@echo "  Running example$(EXE) via nanvixd$(EXE)..."
-	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd$(EXE) -- $(abspath example$(EXE)) /tmp/zlib_test
+	cd "$(SYSROOT_PATH)" && timeout --foreground 120 ./bin/nanvixd$(EXE) -- $(abspath $(TEST_OUT)/example$(EXE)) /tmp/zlib_test
 	@echo "  PASS: example test (exit code 0)"
 endif
 	@echo "  PASS: zlib functional tests"
@@ -141,18 +139,29 @@ test: test-functional
 package:
 	@echo "=== Packaging zlib release ==="
 	$(eval ARTIFACT_NAME := zlib-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
-	@for f in $(RELEASE_ARTIFACTS); do \
-		if [ ! -f "$$f" ]; then \
-			echo "  FAIL: Required artifact not found: $$f"; exit 1; \
-		fi; \
-	done
 	rm -rf dist/$(ARTIFACT_NAME)
 	mkdir -p dist/$(ARTIFACT_NAME)/sysroot/lib \
 		dist/$(ARTIFACT_NAME)/sysroot/include \
 		dist/$(ARTIFACT_NAME)/sysroot/bin
-	cp -f $(STATICLIB) dist/$(ARTIFACT_NAME)/sysroot/lib/
-	cp -f zlib.h zconf.h dist/$(ARTIFACT_NAME)/sysroot/include/
-	-cp -f $(TEST_PROGS) dist/$(ARTIFACT_NAME)/sysroot/bin/ 2>/dev/null || true
+	@for f in $(LIB_ARTIFACTS); do \
+		if [ ! -f "$(LIB_OUT)/$$f" ]; then \
+			echo "  FAIL: Required artifact not found: $(LIB_OUT)/$$f"; exit 1; \
+		fi; \
+		cp -f "$(LIB_OUT)/$$f" dist/$(ARTIFACT_NAME)/sysroot/lib; \
+	done
+	@for f in $(INCLUDE_ARTIFACTS); do \
+		if [ ! -f "$(INCLUDE_OUT)/$$f" ]; then \
+			echo "  FAIL: Required artifact not found: $(INCLUDE_OUT)/$$f"; exit 1; \
+		fi; \
+		cp -f "$(INCLUDE_OUT)/$$f" dist/$(ARTIFACT_NAME)/sysroot/include; \
+	done
+	@for f in $(TEST_ARTIFACTS); do \
+		if [ ! -f "$(TEST_OUT)/$$f" ]; then \
+            echo "  WARNING: Optional artifact $(TEST_OUT)/$$f not found (skipping): $$f"; \
+            continue; \
+		fi; \
+		cp -f "$(TEST_OUT)/$$f" dist/$(ARTIFACT_NAME)/sysroot/bin/; \
+	done
 	tar -czf dist/$(ARTIFACT_NAME).tar.gz -C dist/$(ARTIFACT_NAME) sysroot
 	@echo "  Package: dist/$(ARTIFACT_NAME).tar.gz"
 	@echo "  Contents:"
@@ -181,8 +190,7 @@ verify-package:
 # ===========================================================================
 
 clean:
-	rm -f *.o test/*.o *~ $(STATICLIB) $(TEST_PROGS)
-	rm -f *.a *$(EXE)
+	rm -rf $(OUT_DIR)
 	rm -rf dist/
 
 .PHONY: all clean test test-functional package verify-package

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -12,7 +12,9 @@ Usage:
 """
 
 import dataclasses
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 from nanvix_zutil import (
@@ -46,6 +48,16 @@ _MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
 _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
+
+LIB_ARTIFACTS = ["libz.a"]
+INCLUDE_ARTIFACTS = ["zlib.h", "zconf.h"]
+TEST_ARTIFACTS = ["example.elf", "minigzip.elf"]
+NANVIX_ROOT = Path(__file__).resolve().parent
+OUT_DIR = NANVIX_ROOT / "out"
+DIST_DIR = NANVIX_ROOT / "dist"
+LIB_OUT = OUT_DIR / "build" / "lib"
+INCLUDE_OUT = OUT_DIR / "build" / "include"
+TEST_OUT = OUT_DIR / "test"
 
 
 class ZlibBuild(ZScript):
@@ -83,6 +95,9 @@ class ZlibBuild(ZScript):
             self.docker.translate_path(Path(sysroot)) if self.docker else Path(sysroot)
         )
 
+        def translate(p: Path):
+            return self.docker.translate_path(p) if self.docker else p
+
         args = [
             "make",
             "-f",
@@ -92,6 +107,15 @@ class ZlibBuild(ZScript):
             f"{_MAKE_VAR_PLATFORM}={self.config.machine}",
             f"{_MAKE_VAR_PROCESS_MODE}={self.config.deployment_mode}",
             f"{_MAKE_VAR_MEMORY_SIZE}={self.config.memory_size}",
+            f"LIB_ARTIFACTS={' '.join(LIB_ARTIFACTS)}",
+            f"INCLUDE_ARTIFACTS={' '.join(INCLUDE_ARTIFACTS)}",
+            f"TEST_ARTIFACTS={' '.join(TEST_ARTIFACTS)}",
+            f"NANVIX_ROOT={translate(NANVIX_ROOT)}",
+            f"OUT_DIR={translate(OUT_DIR)}",
+            f"DIST_DIR={translate(DIST_DIR)}",
+            f"LIB_OUT={translate(LIB_OUT)}",
+            f"INCLUDE_OUT={translate(INCLUDE_OUT)}",
+            f"TEST_OUT={translate(TEST_OUT)}",
         ]
 
         args.extend(targets)
@@ -103,7 +127,19 @@ class ZlibBuild(ZScript):
 
     def build(self) -> None:
         """Cross-compile libz.a for Nanvix."""
+        LIB_OUT.mkdir(exist_ok=True, parents=True)
+        INCLUDE_OUT.mkdir(exist_ok=True, parents=True)
+        TEST_OUT.mkdir(exist_ok=True, parents=True)
+
         run(*self._make_args("all"), cwd=self.repo_root, docker=self.docker)
+        # TODO: Make initramfs HERE and store it at TEST_OUT
+
+        for lib in LIB_ARTIFACTS:
+            shutil.move(self.repo_root / lib, LIB_OUT / lib)
+        for bin in TEST_ARTIFACTS:
+            shutil.move(self.repo_root / bin, TEST_OUT / bin)
+        for include in INCLUDE_ARTIFACTS:
+            shutil.copy2(self.repo_root / include, INCLUDE_OUT / include)
 
     def test(self) -> None:
         """Run the zlib test suite.
@@ -112,6 +148,15 @@ class ZlibBuild(ZScript):
         The functional test in standalone mode is handled in Python via
         make_initrd so that initrd creation is shared across platforms.
         """
+
+        for bin in TEST_ARTIFACTS:
+            if not (TEST_OUT / bin).is_file():
+                log.fatal(
+                    f"{bin} not found.",
+                    code=EXIT_MISSING_DEP,
+                    hint="Run ./z build first.",
+                )
+
         if IS_WINDOWS:
             self._run_tests_windows()
             return
@@ -128,22 +173,14 @@ class ZlibBuild(ZScript):
         Creates an initrd bundling example.elf with system daemons via
         make_initrd, and a ramfs providing /tmp for test file output.
         """
-        import tempfile
-
-        binary = self.repo_root / "example.elf"
-        if not binary.is_file():
-            log.fatal(
-                "example.elf not found.",
-                code=EXIT_MISSING_DEP,
-                hint="Run `./z build` first.",
-            )
-
         print("=== zlib functional tests ===")
         print("  Running example.elf via nanvixd standalone...")
 
         # Bundle example.elf + daemons into an initrd.
         initrd = make_initrd(
-            self, "example.elf", InitRdArgs(app_args=["tmp/zlib_test"])
+            self,
+            TEST_OUT / "example.elf",
+            InitRdArgs(app_args=["tmp/zlib_test"]),
         )
 
         # Build a ramfs with /tmp for test file output.
@@ -247,12 +284,9 @@ class ZlibBuild(ZScript):
 
         failed: list[str] = []
         for binary in test_binaries:
-            name = binary.stem
-            print(f"RUN  {name}...")
+            print(f"RUN  {binary.stem}...")
             # Bundle the test program in an initrd image.
-            initrd = make_initrd(
-                self, binary.name, InitRdArgs(app_args=["/tmp/zlib_test"])
-            )
+            initrd = make_initrd(self, binary, InitRdArgs(app_args=["/tmp/zlib_test"]))
             # Build a ramfs image with a /tmp directory for test output.
             with tempfile.TemporaryDirectory(prefix=f"nanvix_{name}_") as tmpdir:
                 tmpdir_path = Path(tmpdir)


### PR DESCRIPTION
WIP pending upstream changes on zutils

Changes needed upstream before this works:

- Constant values for output directories
- `make_initrd` should discover files and output them to the corresponding out/ directories.
- Remove non-build steps from zutils's docker-enabled steps.

Probably some changes on this branch still to come.