### PR TITLE
[nanvix] Name release assets per build configuration

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -21,8 +21,10 @@ from nanvix_zutil import (
     TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
+    load_manifest,
     log,
     make_initrd,
+    package,
     run,
 )
 from nanvix_zutil.helpers import InitRdArgs
@@ -32,6 +34,7 @@ from nanvix_zutil.paths import (
     lib_out,
     nanvix_root,
     out_dir,
+    release_dir,
     repo_root,
     test_out,
 )
@@ -325,10 +328,26 @@ class ZlibBuild(ZScript):
             raise RuntimeError(f"{len(failed)} test(s) failed: {msg}")
         print(f"\t\t*** All {len(test_binaries)} tests PASSED ***")
 
-    # def release(self) -> None:
-    #     """Package the zlib release tarball and verify it."""
-    #     run(*self._make_args("package"), cwd=repo_root())
-    #     run(*self._make_args("verify-package"), cwd=repo_root())
+    def release(self) -> None:
+        """Package the zlib release archive named per build configuration.
+
+        The base :meth:`ZScript.release` packages ``release_dir()`` under the
+        bare package name (``zlib``), so every matrix configuration emits an
+        identically-named ``zlib.tar.gz``/``zlib.zip``; in CI these collide and
+        overwrite one another, leaving the published release with only generic
+        assets. Dependents resolve assets by the pattern
+        ``{name}-{machine}-{mode}-{mem}`` (e.g.
+        ``zlib-microvm-multi-process-128mb``), so the archive must carry that
+        name for dependency installation to succeed.
+        """
+        manifest = load_manifest()
+        name = (
+            f"{manifest.name}"
+            f"-{self.config.machine}"
+            f"-{self.config.deployment_mode}"
+            f"-{self.config.memory_size}"
+        )
+        package([release_dir()], dist_dir(), name)
 
     def clean(self) -> None:
         """Remove build artifacts."""


### PR DESCRIPTION
## Problem

Dependent repos (e.g. `nanvix/sqlite`) fail their Nanvix CI during the **Setup** step with:

```
error: Asset 'zlib-microvm-multi-process-128mb' not found in release nanvix/zlib@1.3.1-nanvix-<ver>
note: while installing dependency 'zlib' (nanvix/zlib@1.3.1-nanvix-<ver>)
```

Recent `nanvix/zlib` releases (e.g. `1.3.1-nanvix-0.16.32`) publish only generic `zlib.tar.gz` / `zlib.zip` assets, whereas working releases (e.g. `1.3.1-nanvix-0.16.17`) published six per-configuration assets like `zlib-microvm-multi-process-128mb.tar.gz`.

## Root cause

During the zutils **v0.11.0** migration the `release()` override in `.nanvix/z.py` was commented out. Execution then falls through to the base `ZScript.release()`:

```python
package([release_dir()], dist_dir(), manifest.name)  # name = "zlib"
```

This names the archive after the bare package name, so **every** matrix configuration emits an identically-named `zlib.tar.gz`/`zlib.zip`. In the reusable release job all matrix artifacts are copied into one directory (`cp {} release-assets/`), so they collide and overwrite each other — leaving the published release with only generic assets.

Consumers still resolve dependency assets via zutils' `artifact_pattern = "{name}-{machine}-{mode}-{mem}"` (`buildroot.py`), i.e. `zlib-microvm-multi-process-128mb`, which no longer exists → dependency install fails.

## Fix

Override `release()` to package the release tree under `{name}-{machine}-{mode}-{mem}`, matching what dependents resolve. Each matrix config now emits a uniquely-named archive, so they no longer collide and all six assets are published.

## Verification

- `python -m py_compile .nanvix/z.py` passes; module imports cleanly against zutils v0.11.1.
- Simulated a populated `release_dir` and ran the new `release()`: produced `zlib-microvm-multi-process-128mb.tar.gz` / `.zip` with the expected `lib/libz.a`, `include/zlib.h`, `include/zconf.h` layout (which the consumer's `_extract_dep_tar` extracts correctly).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>