### PR TITLE
[build] E: Build libz.so alongside libz.a

### DIFF
--- a/.nanvix/Makefile.nanvix
+++ b/.nanvix/Makefile.nanvix
@@ -23,7 +23,6 @@
 
 .DEFAULT_GOAL=all
 EXE = .elf
-_NANVIX_DOCKER_BUILD_GOALS := all install example$(EXE) minigzip$(EXE)
 _NANVIX_GOALS := $(or $(MAKECMDGOALS),$(.DEFAULT_GOAL))
 
 # Ensure required variables are defined
@@ -48,9 +47,10 @@ ifneq ($(filter-out clean,$(_NANVIX_GOALS)),)
   )
 endif
 
-CFLAGS = -O2 -Wall -D_GNU_SOURCE -msse2 -mfpmath=sse
+CFLAGS = -O2 -Wall -fPIC -D_GNU_SOURCE -msse2 -mfpmath=sse
 ARFLAGS = rc
 STATICLIB = libz.a
+SHAREDLIB = libz.so
 OBJZ = adler32.o crc32.o deflate.o infback.o inffast.o inflate.o inftrees.o trees.o zutil.o
 OBJG = compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o
 OBJS = $(OBJZ) $(OBJG)
@@ -60,6 +60,8 @@ SYSROOT_PATH := $(abspath $(NANVIX_HOME))
 # Build Mode Variables
 # ===========================================================================
 
+# Defined here (after SHAREDLIB) so $(SHAREDLIB) expands to its value.
+_NANVIX_DOCKER_BUILD_GOALS := all install example$(EXE) minigzip$(EXE) $(SHAREDLIB)
 _BUILD := $(filter $(_NANVIX_DOCKER_BUILD_GOALS),$(_NANVIX_GOALS))
 _NONBUILD := $(filter-out $(_NANVIX_DOCKER_BUILD_GOALS),$(_NANVIX_GOALS))
 ifneq ($(_BUILD),)
@@ -94,11 +96,11 @@ NANVIX_LIBS := -Wl,--start-group \
 # Build Targets
 # ===========================================================================
 
-all: $(STATICLIB) $(TEST_ARTIFACTS) install
+all: $(STATICLIB) $(SHAREDLIB) $(TEST_ARTIFACTS) install
 
 # Stage built artifacts into the release/test output tree so that
 # `./z release` (which packages release_dir()) and `./z test` can find them.
-install: $(STATICLIB) $(TEST_ARTIFACTS)
+install: $(STATICLIB) $(SHAREDLIB) $(TEST_ARTIFACTS)
 	@mkdir -p $(LIB_OUT) $(INCLUDE_OUT) $(TEST_OUT)
 	cp -f $(LIB_ARTIFACTS)     $(LIB_OUT)/
 	cp -f $(INCLUDE_ARTIFACTS) $(INCLUDE_OUT)/
@@ -107,6 +109,21 @@ install: $(STATICLIB) $(TEST_ARTIFACTS)
 $(STATICLIB): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)
 	-@ ($(RANLIB) $@ || true) >/dev/null 2>&1
+
+# Link libz.so from the (now PIC) static archive via --whole-archive
+# so every zlib entry point becomes part of the .so's .dynsym.  Set
+# DT_SONAME so consumers that link `-lz` against this .so emit a
+# proper DT_NEEDED entry.  libz is self-contained -- no transitive
+# .so deps -- so nothing else to record; libc / libm symbols (memcpy,
+# memset, ...) are left UND via -nostdlib and bind at dlopen time
+# against the host executable's .dynsym, the same model used by
+# the same model already used by other Nanvix shared libraries such as
+# libffi.so / libssl.so.
+$(SHAREDLIB): $(STATICLIB)
+	$(CC) -shared -fPIC -nostdlib \
+	    -Wl,-soname,$(SHAREDLIB) -Wl,-z,noexecstack \
+	    -Wl,--whole-archive $(STATICLIB) -Wl,--no-whole-archive \
+	    -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/.nanvix/README.md
+++ b/.nanvix/README.md
@@ -195,6 +195,6 @@ All 12 platform configurations run in parallel with `fail-fast: false`.
 
 ## Limitations
 
-- **Static linking only.** Shared libraries (`libz.so`) are not supported on Nanvix.
+- **Shared library built manually.** `libz.so` is produced by linking the PIC static archive with `gcc -shared -Wl,--whole-archive`; the upstream `configure`/libtool shared-build path is not used (it does not support `i686-nanvix`).
 - **No `configure` step.** The upstream `./configure` script is not used. Build configuration is hardcoded in `.nanvix/Makefile.nanvix`.
 - **KVM required for functional tests.** The `test-functional` target needs `/dev/kvm` access to run `nanvixd.elf`.

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -51,7 +51,7 @@ _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 
-LIB_ARTIFACTS = ["libz.a"]
+LIB_ARTIFACTS = ["libz.a", "libz.so"]
 INCLUDE_ARTIFACTS = ["zlib.h", "zconf.h"]
 TEST_ARTIFACTS = ["example.elf", "minigzip.elf"]
 
@@ -79,10 +79,12 @@ class ZlibBuild(ZScript):
         output_files = [
             # In-tree build artifacts (legacy locations used by tests).
             "libz.a",
+            "libz.so",
             "example.elf",
             "minigzip.elf",
             # Installed artifacts staged for `./z release` / packaging.
             str((lib_out() / "libz.a").relative_to(root)),
+            str((lib_out() / "libz.so").relative_to(root)),
             str((include_out() / "zlib.h").relative_to(root)),
             str((include_out() / "zconf.h").relative_to(root)),
             str((test_out() / "example.elf").relative_to(root)),
@@ -135,7 +137,7 @@ class ZlibBuild(ZScript):
         return super().setup()
 
     def build(self) -> None:
-        """Cross-compile libz.a for Nanvix."""
+        """Cross-compile libz.a and libz.so for Nanvix."""
         run(*self._make_args("all"), cwd=repo_root(), docker=self.docker)
 
     def test(self) -> None:


### PR DESCRIPTION
## Summary

Adds a SHAREDLIB target to `.nanvix/Makefile.nanvix` so the zlib port builds `libz.so` alongside the existing `libz.a`. This lets consumers `dlopen` zlib at run time instead of statically linking it.

## Why

Today the Nanvix zlib port ships only `libz.a`. Anything that wants zlib (e.g., cpython's `zlib` extension) has to statically embed it into the consumer binary. That works for cpython's monolithic `python.elf` but does not allow:

- Sharing a single libz implementation across multiple `.so` consumers in the same process.
- Building a cpython `zlib.so` that resolves zlib via `DT_NEEDED libz.so` (the model already used by `_ssl.so` → `libssl.so` and `_ctypes.so` → `libffi.so` on Nanvix).

Producing `libz.so` here unblocks the cpython migration of `zlib` from `--whole-archive .a in python.elf` to `DT_NEEDED .so`.

## What changed

- `.nanvix/Makefile.nanvix`:
  - `STATICLIB = libz.a` joined by `SHAREDLIB = libz.so`.
  - `CFLAGS` gains `-fPIC` so the same `.o` files compile into both `.a` and `.so`.
  - New `$(SHAREDLIB)` rule links the `.so` from the `.a` via `-Wl,--whole-archive` with `DT_SONAME=libz.so` and `-nostdlib` (libc / libm UND, bind at dlopen).
  - `all`, `install`, and `_NANVIX_DOCKER_BUILD_GOALS` extended to cover the `.so`. `package` / `verify-package` automatically pick it up via `LIB_ARTIFACTS`.
- `.nanvix/z.py`:
  - `LIB_ARTIFACTS` gains `"libz.so"`.
  - `output_files` extended with `libz.so` (and its `lib_out()` counterpart) so `./z build` copies it back to the workspace.

## Architecture

```
libz.so          ~110 KB
  └── UND libc / libm symbols (memcpy, memset, malloc, ...)
      → resolved against the host executable's .dynsym at dlopen time

libz.a (unchanged)
  └── same .o files compiled with -fPIC
```

`libz.so` has no transitive `.so` dependencies (libz is self-contained; libc/libm symbols are UND), so the loader does not need to walk any DT_NEEDED chain to load it.

## Dependencies

**Runtime dep (already merged upstream):**

- [nanvix/nanvix#2473](https://github.com/nanvix/nanvix/pull/2473) — `dlfcn` init-array + DT_RUNPATH support. Required for any consumer to `dlopen("libz.so")` at run time.

## Validation

Build runs end-to-end inside the toolchain-gcc Docker image:

```
$ ./z build
... (compiles 15 .o files with -fPIC) ...
ar rc libz.a adler32.o crc32.o deflate.o infback.o inffast.o inflate.o ...
i686-nanvix-gcc -shared -fPIC -nostdlib \
    -Wl,-soname,libz.so -Wl,-z,noexecstack \
    -Wl,--whole-archive libz.a -Wl,--no-whole-archive \
    -o libz.so
success: Build complete
```

Structural verification of the produced `libz.so`:

```
$ i686-nanvix-readelf -d libz.so | grep -E 'SONAME|NEEDED'
 0x0000000e (SONAME)                     Library soname: [libz.so]

$ i686-nanvix-nm -D libz.so | grep -E ' T (deflate|inflate|crc32|adler32)' | head -5
00001ae0 T adler32
00001b10 T adler32_combine
00001bd0 T adler32_combine64
00001720 T adler32_z
00002090 T crc32
```

SONAME correctly set, no spurious DT_NEEDED, public API (`deflate*`, `inflate*`, `crc32*`, `adler32*`) exported, libc symbols left UND for runtime binding. The existing `libz.a` / `example.elf` / `minigzip.elf` test binaries are unchanged.
