### PR TITLE
[ci] Bump nanvix-version to 0.16.140

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zlib"
 version = "1.3.1"
-nanvix-version = "0.16.134"
+nanvix-version = "0.16.140"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Bumps `nanvix-version` from `0.16.134` to `0.16.140` in `.nanvix/nanvix.toml`.

Part of a coordinated ecosystem bump across all repositories listed in nanvix/workflows tier-config.json.