### PR TITLE
Rm release override

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -21,10 +21,8 @@ from nanvix_zutil import (
     TOOLCHAIN_CONTAINER_PATH,
     DockerConfig,
     ZScript,
-    load_manifest,
     log,
     make_initrd,
-    package,
     run,
 )
 from nanvix_zutil.helpers import InitRdArgs
@@ -34,7 +32,6 @@ from nanvix_zutil.paths import (
     lib_out,
     nanvix_root,
     out_dir,
-    release_dir,
     repo_root,
     test_out,
 )
@@ -327,27 +324,6 @@ class ZlibBuild(ZScript):
             msg = " ".join(failed)
             raise RuntimeError(f"{len(failed)} test(s) failed: {msg}")
         print(f"\t\t*** All {len(test_binaries)} tests PASSED ***")
-
-    def release(self) -> None:
-        """Package the zlib release archive named per build configuration.
-
-        The base :meth:`ZScript.release` packages ``release_dir()`` under the
-        bare package name (``zlib``), so every matrix configuration emits an
-        identically-named ``zlib.tar.gz``/``zlib.zip``; in CI these collide and
-        overwrite one another, leaving the published release with only generic
-        assets. Dependents resolve assets by the pattern
-        ``{name}-{machine}-{mode}-{mem}`` (e.g.
-        ``zlib-microvm-multi-process-128mb``), so the archive must carry that
-        name for dependency installation to succeed.
-        """
-        manifest = load_manifest()
-        name = (
-            f"{manifest.name}"
-            f"-{self.config.machine}"
-            f"-{self.config.deployment_mode}"
-            f"-{self.config.memory_size}"
-        )
-        package([release_dir()], dist_dir(), name)
 
     def clean(self) -> None:
         """Remove build artifacts."""


### PR DESCRIPTION
Removes the redundant release override; the base `ZScript.release()` in nanvix-zutil v0.12.0 already implements the same suffix-naming pattern (`{name}-{machine}-{deployment_mode}-{memory_size}`).

Verified the full lifecycle on Linux and Windows before and after the change: release archive filenames and contents match.

Towards nanvix/zutils#191.