### PR TITLE
[ci] E: Update nanvix workflow refs to v2.3.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.2.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.3.0
     with:
       platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'
@@ -42,7 +42,7 @@ jobs:
 
   ci-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.2.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.3.0
     with:
       platforms: '["microvm"]'
       process-modes: '["multi-process","single-process","standalone"]'

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -252,12 +252,14 @@ class ZlibBuild(ZScript):
                 hint="Run `./z setup` first.",
             )
 
-        # The Makefile outputs ELFs directly to the repository root, not to a
-        # build/ subdirectory.  Search the repo root first; fall back to build/
-        # for forward-compatibility in case a future Makefile change moves them.
+        # Search `test_out()` (`.nanvix/out/test/`), which is the contract
+        # location both for Linux installs and for the windows-ci artifact
+        # overlay (see `_stage_artifacts_elf_so` in nanvix_scripts). Fall
+        # back to the repo root and `build/` for robustness against future
+        # Makefile changes.
         test_allowlist = {"example.elf"}
         test_binaries: list[Path] = []
-        for candidate in [repo_root(), repo_root() / "build"]:
+        for candidate in [test_out(), repo_root(), repo_root() / "build"]:
             if candidate.is_dir():
                 elfs = sorted(candidate.glob("*.elf"))
                 found = [b for b in elfs if b.name in test_allowlist]
@@ -275,10 +277,21 @@ class ZlibBuild(ZScript):
 
         import tempfile
 
+        import shutil
+
         failed: list[str] = []
         for binary in test_binaries:
             name = binary.stem
             print(f"RUN  {name}...")
+            # make_initrd reads the app ELF from `repo_root() / <name>`
+            # (hardcoded in nanvix_zutil.helpers). The windows-ci overlay
+            # only stages artifacts under `test_out()`, so copy the binary
+            # up to the repo root if it isn't already there.
+            staged = repo_root() / binary.name
+            staged_created = False
+            if binary.resolve() != staged.resolve():
+                shutil.copy2(binary, staged)
+                staged_created = True
             # Bundle the test program in an initrd image.
             initrd = make_initrd(
                 self,
@@ -319,6 +332,8 @@ class ZlibBuild(ZScript):
                 finally:
                     if initrd.exists():
                         initrd.unlink()
+                    if staged_created:
+                        staged.unlink(missing_ok=True)
 
         if failed:
             msg = " ".join(failed)


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.3.0`](https://github.com/nanvix/workflows/releases/tag/v2.3.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.