### PR TITLE
fix(windows-ci): discover test binaries in test_out()

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -252,12 +252,14 @@ class ZlibBuild(ZScript):
                 hint="Run `./z setup` first.",
             )
 
-        # The Makefile outputs ELFs directly to the repository root, not to a
-        # build/ subdirectory.  Search the repo root first; fall back to build/
-        # for forward-compatibility in case a future Makefile change moves them.
+        # Search `test_out()` (`.nanvix/out/test/`), which is the contract
+        # location both for Linux installs and for the windows-ci artifact
+        # overlay (see `_stage_artifacts_elf_so` in nanvix_scripts). Fall
+        # back to the repo root and `build/` for robustness against future
+        # Makefile changes.
         test_allowlist = {"example.elf"}
         test_binaries: list[Path] = []
-        for candidate in [repo_root(), repo_root() / "build"]:
+        for candidate in [test_out(), repo_root(), repo_root() / "build"]:
             if candidate.is_dir():
                 elfs = sorted(candidate.glob("*.elf"))
                 found = [b for b in elfs if b.name in test_allowlist]
@@ -275,10 +277,21 @@ class ZlibBuild(ZScript):
 
         import tempfile
 
+        import shutil
+
         failed: list[str] = []
         for binary in test_binaries:
             name = binary.stem
             print(f"RUN  {name}...")
+            # make_initrd reads the app ELF from `repo_root() / <name>`
+            # (hardcoded in nanvix_zutil.helpers). The windows-ci overlay
+            # only stages artifacts under `test_out()`, so copy the binary
+            # up to the repo root if it isn't already there.
+            staged = repo_root() / binary.name
+            staged_created = False
+            if binary.resolve() != staged.resolve():
+                shutil.copy2(binary, staged)
+                staged_created = True
             # Bundle the test program in an initrd image.
             initrd = make_initrd(
                 self,
@@ -319,6 +332,8 @@ class ZlibBuild(ZScript):
                 finally:
                     if initrd.exists():
                         initrd.unlink()
+                    if staged_created:
+                        staged.unlink(missing_ok=True)
 
         if failed:
             msg = " ".join(failed)


### PR DESCRIPTION
## What

Teach `_run_tests_windows()` to look for test ELFs in `paths.test_out()` (i.e. `.nanvix/out/test/`), with `repo_root()` and `repo_root()/build/` kept as fallbacks.

## Why

`nanvix/workflows@v2.3.0` (commit `f06ad3f`) tightened the windows-test upload contract to `${test-output-path}/**/*.{elf,so}` (default `.nanvix/out/test`) and downloads the artifact back into the same path on the Windows runner. The companion local sim (`_stage_artifacts_elf_so` in `nanvix_scripts/test_windows.py`) already mirrors this.

Before this PR, `_run_tests_windows()` only searched `repo_root()` and `repo_root()/build/`, so neither the local windows-ci sim nor the real CI could locate the staged ELF, and the test step exited with "No allowlisted test binaries found. Expected: example.elf." — which is what's blocking the automated workflow-ref bump PR #273.

## How

* Prepend `test_out()` to the candidate search list.
* `nanvix_zutil.helpers.make_initrd` in zutils v0.13.0 (currently pinned) still hardcodes `repo_root() / app` as the ELF source path, so we copy the discovered binary up to the repo root just before `make_initrd` and remove it after. The contract-mismatch in `make_initrd` itself is a zutils-side fix and intentionally out of scope here.

## Verification

`just lc` (linux + windows-ci sim) — all relevant phases pass; in particular:

```
 OK  linux_test            linux     exit=0
 OK  windows-ci_test       windows   exit=0
```

with the Windows-side output showing `RUN example / OK example / *** All 1 tests PASSED ***`. The `windows_build` phase (native end-to-end Windows build) is unrelated and fails on a local Docker Desktop daemon issue.

## Followups

* Once this merges, PR #273 (workflow ref bump to v2.3.0) will go green on its own.
* The remaining downstreams need analogous fixes; tracking work item TBD.