### PR TITLE
[zlib] Migrate to Nanvix SDK

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -35,7 +35,8 @@ jobs:
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"  # yamllint disable-line rule:line-length
+      docker-image: >-
+        ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -51,7 +52,8 @@ jobs:
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
       windows-test: true
-      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"  # yamllint disable-line rule:line-length
+      docker-image: >-
+        ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       platforms: '["microvm"]'
       process-modes: '["standalone"]'
-      memory-sizes: '["128mb","256mb"]'
+      memory-sizes: '["256mb"]'
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
@@ -47,7 +47,7 @@ jobs:
     with:
       platforms: '["microvm"]'
       process-modes: '["standalone"]'
-      memory-sizes: '["128mb","256mb"]'
+      memory-sizes: '["256mb"]'
       windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'

--- a/.nanvix/Makefile.nanvix
+++ b/.nanvix/Makefile.nanvix
@@ -56,8 +56,6 @@ STATICLIB = libz.a
 OBJZ = adler32.o crc32.o deflate.o infback.o inffast.o inflate.o inftrees.o trees.o zutil.o
 OBJG = compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o
 OBJS = $(OBJZ) $(OBJG)
-SYSROOT_PATH := $(abspath $(NANVIX_HOME))
-
 # ===========================================================================
 # Build Mode Variables
 # ===========================================================================
@@ -70,27 +68,18 @@ ifneq ($(_BUILD),)
     $(error Cannot mix build and non-build targets. Build targets: $(_NANVIX_DOCKER_BUILD_GOALS))
   endif
 
-  ifeq ($(wildcard $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc),)
-      $(error Nanvix toolchain not found at $(NANVIX_TOOLCHAIN))
+  ifeq ($(wildcard $(NANVIX_TOOLCHAIN)/nanvix-sdk.json),)
+      $(error Nanvix SDK not found at $(NANVIX_TOOLCHAIN))
+  endif
+  ifeq ($(wildcard $(NANVIX_TOOLCHAIN)/bin/clang),)
+      $(error Nanvix SDK Clang not found at $(NANVIX_TOOLCHAIN)/bin/clang)
   endif
 endif
 
-CC := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-gcc
-AR := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-ar
-RANLIB := $(NANVIX_TOOLCHAIN)/bin/i686-nanvix-ranlib
-# Since Nanvix 0.16.19, process startup (`_start`) lives in libnvx_crt0.a; it
-# drives `__nanvix_libc_start_main` in libposix.a. It must be linked first so
-# its strong `_start` overrides the toolchain's weak no-op stub (otherwise the
-# guest never reaches main and hangs). libnvx_crt0.a and libposix.a share some
-# kcall objects, so allow multiple definitions to resolve the overlap.
-NANVIX_LDFLAGS := -T$(SYSROOT_PATH)/lib/user.ld -static -Wl,-z,noexecstack -Wl,--allow-multiple-definition
-NANVIX_LIBS := -Wl,--start-group \
-  $(SYSROOT_PATH)/lib/libnvx_crt0.a \
-  $(SYSROOT_PATH)/lib/libposix.a \
-  $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a \
-  $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a \
-  -Wl,--end-group
-
+CC := $(NANVIX_TOOLCHAIN)/bin/clang
+AR := $(NANVIX_TOOLCHAIN)/bin/llvm-ar
+RANLIB := $(NANVIX_TOOLCHAIN)/bin/llvm-ranlib
+NANVIX_LDFLAGS := -Wl,-z,noexecstack
 
 # ===========================================================================
 # Build Targets
@@ -120,10 +109,10 @@ test/minigzip.o: test/minigzip.c zlib.h zconf.h
 	$(CC) $(CFLAGS) -I. -c -o $@ $<
 
 example$(EXE): test/example.o $(STATICLIB)
-	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ "test/example.o" -L. -lz $(NANVIX_LIBS)
+	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ "test/example.o" -L. -lz
 
 minigzip$(EXE): test/minigzip.o $(STATICLIB)
-	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ "test/minigzip.o" -L. -lz $(NANVIX_LIBS)
+	$(CC) $(CFLAGS) $(NANVIX_LDFLAGS) -o $@ "test/minigzip.o" -L. -lz
 
 # Source dependencies
 adler32.o: adler32.c zutil.h zlib.h zconf.h

--- a/.nanvix/README.md
+++ b/.nanvix/README.md
@@ -175,9 +175,10 @@ Defined in `.nanvix/nanvix.toml` and used by CI:
 | ---- | ------ |
 | Platform | `hyperlight`, `microvm` |
 | Process mode | `standalone` |
-| Memory size | `128mb`, `256mb` |
+| Memory size | `256mb` |
 
-All combinations (2 x 1 x 2 = 4) are built and tested in CI.
+Both platform configurations are built and tested at 256 MB in CI. Nanvix
+`v0.20.0` does not publish a 128 MB runtime asset.
 
 ## CI/CD
 
@@ -192,7 +193,7 @@ Uses the reusable workflow `nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.
 | Schedule | Daily at 09:00 UTC |
 | Manual | `workflow_dispatch` |
 
-All 4 platform configurations run in parallel with `fail-fast: false`.
+All platform configurations run in parallel with `fail-fast: false`.
 
 ## Limitations
 

--- a/.nanvix/README.md
+++ b/.nanvix/README.md
@@ -53,14 +53,15 @@ No other `.c` or `.h` files were modified. The compression algorithms, public AP
 
 | Component | Value |
 | --------- | ----- |
-| Compiler | `i686-nanvix-gcc` |
-| Archiver | `i686-nanvix-ar` |
-| Ranlib | `i686-nanvix-ranlib` |
-| Docker image | `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` |
+| Compiler | `clang` |
+| Archiver | `llvm-ar` |
+| Ranlib | `llvm-ranlib` |
+| Docker image | `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f` |
 | CFLAGS | `-O2 -Wall -D_GNU_SOURCE -msse2 -mfpmath=sse` |
-| LDFLAGS | `-T user.ld -static -Wl,-z,noexecstack` |
+| LDFLAGS | `-Wl,-z,noexecstack` |
 
-The Makefile auto-detects the toolchain. If the native cross-compiler is not found at `NANVIX_TOOLCHAIN` (default `/opt/nanvix`), it falls back to Docker automatically.
+The Makefile uses the Nanvix SDK at `NANVIX_TOOLCHAIN` (default `/opt/nanvix`).
+The SDK compiler defaults to `i686-unknown-nanvix`.
 
 ### Build Outputs
 
@@ -72,13 +73,13 @@ The Makefile auto-detects the toolchain. If the native cross-compiler is not fou
 
 ### Link Dependencies
 
-All executables are statically linked against:
+All executables are linked through the SDK Clang driver against:
 
 - `libz.a` — this library
-- `libposix.a` — from Nanvix sysroot at `$NANVIX_HOME/lib/`
-- `libc.a` — from Nanvix toolchain
-- `libm.a` — from Nanvix toolchain
-- `user.ld` — linker script from Nanvix sysroot at `$NANVIX_HOME/lib/`
+- Nanvix libc and compiler runtime — from the SDK
+- `crt0.o` and `user.ld` — selected by the SDK Clang driver
+
+The downloaded Nanvix sysroot supplies runtime binaries only.
 
 ## Quick Start
 
@@ -100,7 +101,7 @@ Override the pinned nanvix-zutil version with `NANVIX_ZUTIL_VERSION=<version>`.
 
 ```bash
 # Pull the Docker image
-docker pull ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+docker pull ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
 
 # Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh \
@@ -118,8 +119,8 @@ make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" test
 ### Option C: Native toolchain (no Docker)
 
 ```bash
-export NANVIX_TOOLCHAIN=/path/to/toolchain   # Must contain bin/i686-nanvix-gcc
-export NANVIX_HOME=/path/to/nanvix/sysroot   # Must contain lib/user.ld, lib/libposix.a
+export NANVIX_TOOLCHAIN=/path/to/sdk         # Must contain nanvix-sdk.json and bin/clang
+export NANVIX_HOME=/path/to/nanvix/sysroot   # Runtime binaries used by tests
 make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y
 ```
 
@@ -128,10 +129,10 @@ make -f .nanvix/Makefile.nanvix CONFIG_NANVIX=y
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `CONFIG_NANVIX` | *(required)* | Must be set to enable Nanvix build (recommended `y`) |
-| `NANVIX_HOME` | `$HOME/nanvix` | Path to Nanvix sysroot (must contain `lib/user.ld`) |
-| `NANVIX_TOOLCHAIN` | `/opt/nanvix` | Path to cross-compiler (must contain `bin/i686-nanvix-gcc`) |
+| `NANVIX_HOME` | `$HOME/nanvix` | Path to Nanvix runtime binaries used by tests |
+| `NANVIX_TOOLCHAIN` | `/opt/nanvix` | Path to the Nanvix SDK (must contain `nanvix-sdk.json`) |
 | `CONFIG_NANVIX_DOCKER` | *(auto)* | Set to `y` to force Docker even when native toolchain exists |
-| `NANVIX_DOCKER_IMAGE` | `ghcr.io/nanvix/toolchain-gcc:sha-34a3641` | Docker image for cross-compilation |
+| `NANVIX_DOCKER_IMAGE` | Nanvix c-clang SDK digest | Docker image for cross-compilation |
 | `PLATFORM` | `unknown` | Target platform name (`microvm`, `hyperlight`) |
 | `PROCESS_MODE` | `unknown` | Deployment mode (`standalone`) |
 | `MEMORY_SIZE` | `unknown` | Memory configuration (`128mb`, `256mb`) |

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -7,4 +7,4 @@ nanvix-version = "0.20.0"
 [builds.matrix]
 platforms = ["hyperlight", "microvm"]
 modes = ["standalone"]
-memory = ["128mb", "256mb"]
+memory = ["256mb"]

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zlib"
 version = "1.3.1"
-nanvix-version = "0.17.84"
+nanvix-version = "0.20.0"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -39,7 +39,10 @@ from nanvix_zutil.paths import (
 IS_WINDOWS = sys.platform == "win32"
 
 #: Docker image for cross-compiling Nanvix targets.
-NANVIX_DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
+NANVIX_DOCKER_IMAGE = (
+    "ghcr.io/nanvix/nanvix-sdk-c-clang"
+    "@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
+)
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_HOME = "NANVIX_HOME"
@@ -55,6 +58,19 @@ TEST_ARTIFACTS = ["example.elf", "minigzip.elf"]
 
 class ZlibBuild(ZScript):
     """Build script for nanvix/zlib."""
+
+    # Build-time headers, libraries, startup objects, and linker scripts come
+    # from the SDK. The downloaded sysroot is used only to run tests.
+    SYSROOT_REQUIRED_FILES = (
+        "bin/nanvixd.elf",
+        "bin/kernel.elf",
+        "bin/mkramfs.elf",
+    )
+    SYSROOT_REQUIRED_FILES_WINDOWS = (
+        "bin/nanvixd.exe",
+        "bin/kernel.elf",
+        "bin/mkramfs.exe",
+    )
 
     def docker_image(self) -> str:
         """Return the default Docker image for cross-compilation."""


### PR DESCRIPTION
## Summary
- build zlib with the verified Nanvix Clang SDK image by immutable digest
- link test executables through the SDK driver and keep downloaded artifacts runtime-only
- align the Nanvix runtime with SDK v0.20.0-sdk.1
- use the 256mb matrix because Nanvix v0.20.0 does not publish a 128mb runtime asset

## Local validation
- microvm standalone, 256mb
- Python formatting and type checks