### PR TITLE
[sdk] E: Remove duplicate image pin

### DIFF
--- a/.nanvix/README.md
+++ b/.nanvix/README.md
@@ -56,7 +56,7 @@ No other `.c` or `.h` files were modified. The compression algorithms, public AP
 | Compiler | `clang` |
 | Archiver | `llvm-ar` |
 | Ranlib | `llvm-ranlib` |
-| Docker image | `ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f` |
+| Docker image | Immutable coordinate from `.nanvix/nanvix.toml` |
 | CFLAGS | `-O2 -Wall -D_GNU_SOURCE -msse2 -mfpmath=sse` |
 | LDFLAGS | `-Wl,-z,noexecstack` |
 
@@ -100,8 +100,7 @@ Override the pinned nanvix-zutil version with `NANVIX_ZUTIL_VERSION=<version>`.
 ### Option B: Direct Make with Docker
 
 ```bash
-# Pull the Docker image
-docker pull ghcr.io/nanvix/nanvix-sdk-c-clang@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f
+# Pull the image referenced by .nanvix/nanvix.toml before invoking Make.
 
 # Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh \

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -38,12 +38,6 @@ from nanvix_zutil.paths import (
 
 IS_WINDOWS = sys.platform == "win32"
 
-#: Docker image for cross-compiling Nanvix targets.
-NANVIX_DOCKER_IMAGE = (
-    "ghcr.io/nanvix/nanvix-sdk-c-clang"
-    "@sha256:f61737cb0780e6a2058c6d0bdf8ae5562db18de437173b2bcbbe6973abd3689f"
-)
-
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_HOME = "NANVIX_HOME"
 _MAKE_VAR_TOOLCHAIN = "NANVIX_TOOLCHAIN"
@@ -71,10 +65,6 @@ class ZlibBuild(ZScript):
         "bin/kernel.elf",
         "bin/mkramfs.exe",
     )
-
-    def docker_image(self) -> str:
-        """Return the default Docker image for cross-compilation."""
-        return NANVIX_DOCKER_IMAGE
 
     def docker_config(self, image: str) -> DockerConfig:
         """Extend the default Docker config with build artifact copy-back.


### PR DESCRIPTION
Remove the dead z.py image override and point direct-build documentation at the canonical manifest. Lint and strict typing pass.