### PR TITLE
[ci] E: Update Nanvix SDK

### DIFF
--- a/.nanvix/nanvix.lock
+++ b/.nanvix/nanvix.lock
@@ -2,7 +2,7 @@
 
 [metadata]
 manifest-hash = "sha256:79c66dfde0efb1b747e06d79b927c30eaa5b5e27376ad22ec15a83842e9d9403"
-nanvix-zutil-version = "0.16.3"
+nanvix-zutil-version = "0.15.0"
 
 [metadata.sdk]
 schema-version = 1


### PR DESCRIPTION
Automated coherent update to verified Nanvix SDK `v0.21.43-sdk.1`. The manifest and lockfile were generated atomically by the target zutils implementation.